### PR TITLE
Add missing slash

### DIFF
--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -23,7 +23,7 @@ if find tests/output/coverage/ -mindepth 1 -name '.*' -prune -o -print -quit | g
         bash <(curl -s https://codecov.io/bash) \
             -f "${file}" \
             -F "${flags}" \
-            -t c481ab27-5cd1-4c7d-bf2f-3f0ed4c836cc
+            -t c481ab27-5cd1-4c7d-bf2f-3f0ed4c836cc \
             -X coveragepy \
             -X gcov \
             -X fix \


### PR DESCRIPTION
##### SUMMARY

Add missing slash to codecov upload command. @gundalow this command still worked but the lack of a slash after the tag chopped off the subsequent flags. Fixed here and in community.cassandra.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/coverage.sh