### PR TITLE
Refactor mongodb_repository role

### DIFF
--- a/roles/mongodb_repository/tasks/Debian.yml
+++ b/roles/mongodb_repository/tasks/Debian.yml
@@ -1,25 +1,21 @@
 ---
-# tasks file for mongodb_repository
-- name: Install debian packages (Debian & Ubuntu)
+# tasks file for mongodb_repository (Debian os_family)
+- name: Install debian packages
   apt:
     name: "{{ debian_packages }}"
     state: present
 
-- name: Add apt key for MongoDB repository (Debian & Ubuntu)
+- name: Add apt key for MongoDB repository
   apt_key:
     url: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"
     state: present
 
-- name: Ensure MongoDB apt repository exists (Ubuntu)
+- name: Ensure MongoDB apt repository exists
   apt_repository:
-    repo: "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/{{ mongodb_version }} multiverse"
+    repo: "deb{{ repo_opts }} https://repo.mongodb.org/apt/{{ ansible_facts.distribution|lower }} {{ ansible_facts.distribution_release }}/mongodb-org/{{ mongodb_version }} {{ component }}"
     state: present
     filename: "mongodb-{{ mongodb_version }}"
-  when: ansible_distribution == "Ubuntu"
-
-- name: Ensure MongoDB apt repository exists (Debian)
-  apt_repository:
-    repo: "deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/{{ mongodb_version }} main"
-    state: present
-    filename: "mongodb-{{ mongodb_version }}"
-  when: ansible_distribution == "Debian"
+  vars:
+    # include initial space in repo_opts
+    repo_opts: "{% if ansible_facts.distribution == 'Ubuntu' %} [ arch=amd64,arm64 ]{% endif %}"
+    component: "{% if ansible_facts.distribution == 'Ubuntu' %}multiverse{% else %}main{% endif %}"

--- a/roles/mongodb_repository/tasks/Debian.yml
+++ b/roles/mongodb_repository/tasks/Debian.yml
@@ -1,0 +1,25 @@
+---
+# tasks file for mongodb_repository
+- name: Install debian packages (Debian & Ubuntu)
+  apt:
+    name: "{{ debian_packages }}"
+    state: present
+
+- name: Add apt key for MongoDB repository (Debian & Ubuntu)
+  apt_key:
+    url: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"
+    state: present
+
+- name: Ensure MongoDB apt repository exists (Ubuntu)
+  apt_repository:
+    repo: "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/{{ mongodb_version }} multiverse"
+    state: present
+    filename: "mongodb-{{ mongodb_version }}"
+  when: ansible_distribution == "Ubuntu"
+
+- name: Ensure MongoDB apt repository exists (Debian)
+  apt_repository:
+    repo: "deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/{{ mongodb_version }} main"
+    state: present
+    filename: "mongodb-{{ mongodb_version }}"
+  when: ansible_distribution == "Debian"

--- a/roles/mongodb_repository/tasks/RedHat.yml
+++ b/roles/mongodb_repository/tasks/RedHat.yml
@@ -1,0 +1,9 @@
+---
+# tasks file for mongodb_repository
+- name: Ensure MongoDB yum repository exists (RedHat)
+  yum_repository:
+    name: "mongodb-{{ mongodb_version }}"
+    description: "Official MongoDB {{ mongodb_version }} yum repo"
+    baseurl: "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/{{ mongodb_version }}/x86_64/"
+    gpgcheck: 1
+    gpgkey: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"

--- a/roles/mongodb_repository/tasks/RedHat.yml
+++ b/roles/mongodb_repository/tasks/RedHat.yml
@@ -1,9 +1,14 @@
 ---
-# tasks file for mongodb_repository
-- name: Ensure MongoDB yum repository exists (RedHat)
+# tasks file for mongodb_repository (RedHat os_family)
+- name: Add mongodb.org gpgkey
+  rpm_key:
+    key: https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc
+    state: present
+
+- name: Ensure MongoDB yum repository exists
   yum_repository:
     name: "mongodb-{{ mongodb_version }}"
     description: "Official MongoDB {{ mongodb_version }} yum repo"
     baseurl: "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/{{ mongodb_version }}/x86_64/"
-    gpgcheck: 1
+    gpgcheck: true
     gpgkey: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"

--- a/roles/mongodb_repository/tasks/main.yml
+++ b/roles/mongodb_repository/tasks/main.yml
@@ -1,36 +1,4 @@
 ---
 # tasks file for mongodb_repository
-- name: Ensure MongoDB yum repository exists (RedHat)
-  yum_repository:
-      name: "mongodb-{{ mongodb_version }}"
-      description: "Official MongoDB {{ mongodb_version }} yum repo"
-      baseurl: "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/{{ mongodb_version }}/x86_64/"
-      gpgcheck: 1
-      gpgkey: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"
-  when: ansible_os_family == "RedHat"
-
-- name: Install debian packages (Debian & Ubuntu)
-  apt:
-    name: "{{ debian_packages }}"
-    state: present
-  when: ansible_os_family == "Debian"
-
-- name: Add apt key for MongoDB repository (Debian & Ubuntu)
-  apt_key:
-    url: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"
-    state: present
-  when: ansible_os_family == "Debian"
-
-- name: Ensure MongoDB apt repository exists (Ubuntu)
-  apt_repository:
-    repo: "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/{{ mongodb_version }} multiverse"
-    state: present
-    filename: "mongodb-{{ mongodb_version }}"
-  when: ansible_distribution == "Ubuntu"
-
-- name: Ensure MongoDB apt repository exists (Debian)
-  apt_repository:
-    repo: "deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/{{ mongodb_version }} main"
-    state: present
-    filename: "mongodb-{{ mongodb_version }}"
-  when: ansible_distribution == "Debian"
+- name: Include OS-specific tasks
+  include_tasks: "{{ ansible_facts.os_family }}.yml"


### PR DESCRIPTION
##### SUMMARY
Reorganize the tasks into os_family-specific files and add a task to explicitly add the rpm key, like we already do for apt.
Plus a few other cleanups.

It may be easiest to look through this PR one commit at a time. With so many minor changes, it would be difficult to split this into PRs because I couldn't submit them in parallel.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mongodb_repository role
