### PR TITLE
Retry network-dependent tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
+---
 language: python
 python:
   - "2.7"
   - "3.5"
   - "3.6"
 env:
-  if: branch = master
   jobs:
     - MONGODB_ROLE="roles/mongodb_config"
     - MONGODB_ROLE="roles/mongodb_install"

--- a/roles/mongodb_config/tasks/main.yml
+++ b/roles/mongodb_config/tasks/main.yml
@@ -17,6 +17,9 @@
 - name: Ensure mongod package is installed
   package:
     name: "{{ mongod_package }}"
+  register: _pkg
+  until: _pkg is succeeded
+  retries: 5
 
 - name: Ensure db_path dir exists
   file:

--- a/roles/mongodb_install/tasks/main.yml
+++ b/roles/mongodb_install/tasks/main.yml
@@ -5,6 +5,9 @@
     name: mongodb-org
     state: present
   when: specific_mongodb_version is not defined
+  register: _pkg
+  until: _pkg is succeeded
+  retries: 5
 
 - name: Install MongoDB Packages (Specific version)
   package:
@@ -13,6 +16,9 @@
   when:
     - specific_mongodb_version is defined
     - ansible_facts.os_family == "RedHat"
+  register: _pkg
+  until: _pkg is succeeded
+  retries: 5
 
 # apt silliness:
 # In order to upgrade/downgrade to a specific version of mongodb-org,
@@ -30,3 +36,6 @@
   when:
     - specific_mongodb_version is defined
     - ansible_facts.os_family == "Debian"
+  register: _pkg
+  until: _pkg is succeeded
+  retries: 5

--- a/roles/mongodb_linux/tasks/main.yml
+++ b/roles/mongodb_linux/tasks/main.yml
@@ -31,6 +31,9 @@
   package:
     name: "{{ ntp_package }}"
     state: present
+  register: _pkg
+  until: _pkg is succeeded
+  retries: 5
 
 - name: Update perms on chrony pid dir on RedHat 8
   file:
@@ -52,6 +55,9 @@
   package:
     name: "{{ gnu_c_lib }}"
     state: latest
+  register: _pkg
+  until: _pkg is succeeded
+  retries: 5
 
 - name: Ensure NUMA zone reclaim is disabled
   sysctl:

--- a/roles/mongodb_mongod/tasks/main.yml
+++ b/roles/mongodb_mongod/tasks/main.yml
@@ -22,6 +22,9 @@
 - name: Ensure mongod package is installed
   package:
     name: "{{ mongod_package }}"
+  register: _pkg
+  until: _pkg is succeeded
+  retries: 5
 
 - name: Ensure db_path dir exists
   file:

--- a/roles/mongodb_mongos/tasks/main.yml
+++ b/roles/mongodb_mongos/tasks/main.yml
@@ -72,6 +72,9 @@
 - name: Ensure mongos package is installed
   package:
     name: "{{ mongos_package }}"
+  register: _pkg
+  until: _pkg is succeeded
+  retries: 5
 
 - name: Start mongos service
   service:

--- a/roles/mongodb_repository/tasks/Debian.yml
+++ b/roles/mongodb_repository/tasks/Debian.yml
@@ -4,11 +4,17 @@
   apt:
     name: "{{ debian_packages }}"
     state: present
+  register: _apt
+  until: _apt is succeeded
+  retries: 5
 
 - name: Add apt key for MongoDB repository
   apt_key:
     url: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"
     state: present
+  register: _apt
+  until: _apt is succeeded
+  retries: 5
 
 - name: Ensure MongoDB apt repository exists
   apt_repository:
@@ -19,3 +25,6 @@
     # include initial space in repo_opts
     repo_opts: "{% if ansible_facts.distribution == 'Ubuntu' %} [ arch=amd64,arm64 ]{% endif %}"
     component: "{% if ansible_facts.distribution == 'Ubuntu' %}multiverse{% else %}main{% endif %}"
+  register: _apt
+  until: _apt is succeeded
+  retries: 5

--- a/roles/mongodb_repository/tasks/RedHat.yml
+++ b/roles/mongodb_repository/tasks/RedHat.yml
@@ -4,6 +4,9 @@
   rpm_key:
     key: https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc
     state: present
+  register: _yum
+  until: _yum is succeeded
+  retries: 5
 
 - name: Ensure MongoDB yum repository exists
   yum_repository:
@@ -12,3 +15,6 @@
     baseurl: "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/{{ mongodb_version }}/x86_64/"
     gpgcheck: true
     gpgkey: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"
+  register: _yum
+  until: _yum is succeeded
+  retries: 5

--- a/roles/mongodb_selinux/tasks/main.yml
+++ b/roles/mongodb_selinux/tasks/main.yml
@@ -17,6 +17,9 @@
 - name: Install required packages
   package:
     name: "{{ required_packages }}"
+  register: _pkg
+  until: _pkg is succeeded
+  retries: 5
 
 - name: Copy custom MongoDB SeLinux Policy to Host
   copy:


### PR DESCRIPTION
##### SUMMARY
Add retry to package tasks to handle unreliable network

This will retry the package tasks up to 5 times to deal with possible temporary network partitions.

This also adjusts the travis config so that builds run more judiciously on forks and for PRs like this one.
When a PR touches multiple roles (as this one does) it was trying to run the tests for all roles in each travis job.
That made it time out, so this fixes that.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mongodb_config role
mongodb_install role
mongodb_linux role
mongodb_mongod role
mongodb_mongos role
mongodb_repository role
mongodb_selinux role