### PR TITLE
Add mongodb_auth role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.6"
 env:
   jobs:
+    - MONGODB_ROLE="roles/mongodb_auth"
     - MONGODB_ROLE="roles/mongodb_config"
     - MONGODB_ROLE="roles/mongodb_install"
     - MONGODB_ROLE="roles/mongodb_linux"

--- a/roles/mongodb_auth/.yamllint
+++ b/roles/mongodb_auth/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/mongodb_auth/README.md
+++ b/roles/mongodb_auth/README.md
@@ -3,6 +3,10 @@ mongodb_auth
 
 A simple role to enable auth on MongoDB servers.
 
+If running this on a MongoDB server that already has an admin user (ie when using this role to audit
+an alternate install method), you must touch `/root/mongodb_admin.success` or you will get an error
+when this role tries to add the admin user again.
+
 Role Variables
 --------------
 

--- a/roles/mongodb_auth/README.md
+++ b/roles/mongodb_auth/README.md
@@ -1,7 +1,11 @@
 mongodb_auth
 ============
 
-A simple role to enable auth on MongoDB servers.
+This role to enables auth on MongoDB servers, adds the first admin user, and adds a list of other users.
+If your mongo instance requires ssl or an alternative auth_mechanism, please use
+[`module_defaults`](https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html)
+to provide the default auth details for `community.mongodb.mongodb_user` (these defaults are ignored
+when adding the initial admin user with the localhost exception).
 
 If running this on a MongoDB server that already has an admin user (ie when using this role to audit
 an alternate install method), you must touch `/root/mongodb_admin.success` or you will get an error

--- a/roles/mongodb_auth/README.md
+++ b/roles/mongodb_auth/README.md
@@ -1,0 +1,48 @@
+mongodb_auth
+============
+
+A simple role to enable auth on MongoDB servers.
+
+Role Variables
+--------------
+
+mongod_host: The domain or ip to use to communicate with mongod. Default localhost.
+mongod_port: The port used by the mongod process. Default 27017.
+mongod_package: The mongod package to install. Default mongodb-org-server.
+authorization: Enable authorization. Default enabled.
+mongodb_admin_db: MongoDB admin database (for adding users). Default admin.
+mongodb_admin_user: MongoDB admin username. Default admin.
+mongodb_admin_pwd: MongoDB admin password. Defaults to value of mongodb_admin_default_pwd.
+mongodb_admin_default_pwd: MongoDB admin password (for parent roles to override without overriding user's password). Default admin.
+mongodb_users: List of additional users to add. Each user dict should include fields: db, user, pwd, roles
+mongodb_force_update_password: Whether or not to force a password update for any users in mongodb_users. Setting this to yes will result in 'changed' on every run, even if the password is the same. Setting this to no only adds a password when creating the user.
+
+IMPORTANT NOTE: It is expected that mongodb_admin_user & mongodb_admin_pwd values be overridden in your own file protected by Ansible Vault. Any production environments should protect these values. For more information see [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
+
+Dependencies
+------------
+
+mongodb_repository
+
+Example Playbook
+----------------
+
+Install MongoDB preparing hosts for a Sharded Cluster.
+
+```yaml
+    - hosts: servers
+      roles:
+         - { role: mongodb_repository }
+         - { role: mongodb_mongod, mongod_port: 27018, sharding: true }
+         - { role: mongodb_auth, mongod_port: 27018, mongod_host: 127.0.0.1, mongodb_admin_pwd: f00b@r }
+```
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Jacob Floyd (https://github.com/cognifloyd)

--- a/roles/mongodb_auth/defaults/main.yml
+++ b/roles/mongodb_auth/defaults/main.yml
@@ -17,8 +17,8 @@ mongodb_admin_roles: "root"
 # Additional users to add.
 mongodb_users: []
 #  - db: somedatabase
-#    username: someuser
-#    password: "S0meP@ss"
+#    user: someuser
+#    pwd: "S0meP@ss"
 #    roles: readWrite
 
 # whether or not to force a password update for any users in mongodb_users

--- a/roles/mongodb_auth/defaults/main.yml
+++ b/roles/mongodb_auth/defaults/main.yml
@@ -1,9 +1,7 @@
 ---
 # defaults file for mongodb_auth
 mongod_port: 27017
-mongod_host: localhost
 mongod_package: "mongodb-org-server"
-mongodb_shell_package: "mongodb-org-shell"
 
 authorization: "enabled"
 
@@ -13,6 +11,8 @@ mongodb_admin_user: admin
 mongodb_admin_pwd: "{{ mongodb_default_admin_pwd }}"
 # The default is separate so other roles can provide a default without overriding a user provided password.
 mongodb_default_admin_pwd: admin
+# allow for alternate admin roles (eg userAdminAnyDatabase)
+mongodb_admin_roles: "root"
 
 # Additional users to add.
 mongodb_users: []

--- a/roles/mongodb_auth/defaults/main.yml
+++ b/roles/mongodb_auth/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+# defaults file for mongodb_auth
+mongod_port: 27017
+mongod_host: localhost
+mongod_package: "mongodb-org-server"
+mongodb_shell_package: "mongodb-org-shell"
+
+authorization: "enabled"
+
+# when adding auth, the login credentials to use
+mongodb_admin_user: admin
+# For production use - please change the admin password!
+mongodb_admin_pwd: "{{ mongodb_default_admin_pwd }}"
+# The default is separate so other roles can provide a default without overriding a user provided password.
+mongodb_default_admin_pwd: admin
+
+# Additional users to add.
+mongodb_users: []
+#  - db: somedatabase
+#    username: someuser
+#    password: "S0meP@ss"
+#    roles: readWrite
+
+# whether or not to force a password update for any users in mongodb_users
+# Setting this to yes will result in 'changed' on every run, even if the password is the same.
+# See the comment in tasks/main.yml for more details.
+mongodb_force_update_password: no

--- a/roles/mongodb_auth/meta/main.yml
+++ b/roles/mongodb_auth/meta/main.yml
@@ -1,0 +1,30 @@
+---
+galaxy_info:
+  author: Jacob Floyd
+  description: Configure auth on MongoDB servers
+
+  license: BSD
+
+  min_ansible_version: 2.9
+
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+  # List tags for your role here, one per line. A tag is a keyword that describes
+  # and categorizes the role. Users find roles by searching for tags. Be sure to
+  # remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+  #       Maximum 20 tags per role.
+
+dependencies: []

--- a/roles/mongodb_auth/molecule/default/Dockerfile.j2
+++ b/roles/mongodb_auth/molecule/default/Dockerfile.j2
@@ -1,0 +1,39 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+# Add systemd-sysv package for Debian to get systemd working (and procps for sysctl) and netbase for firewalld
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 systemd-sysv procps netbase && apt-get clean; \
+    elif [ $(command -v dnf) ] && grep -q 'platform:el8' /etc/os-release ; then dnf makecache && dnf update -y && dnf --assumeyes install python3 sudo python3-devel bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && rm -Rf /usr/share/doc && rm -Rf /usr/share/man && dnf clean all && cp /bin/true /sbin/agetty; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi
+
+{% if item.image == 'centos:8' %}
+# Stuff for systemd https://hub.docker.com/_/centos
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+	systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+	rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /etc/systemd/system/*.wants/*;\
+	rm -f /lib/systemd/system/local-fs.target.wants/*; \
+	rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+	rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+	rm -f /lib/systemd/system/basic.target.wants/*;\
+	rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+VOLUME [ "/sys/fs/cgroup" ]
+CMD ["/sbin/init"]
+{% endif %}

--- a/roles/mongodb_auth/molecule/default/molecule.yml
+++ b/roles/mongodb_auth/molecule/default/molecule.yml
@@ -1,0 +1,50 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-data:
+      line-length: disable
+platforms:
+  - name: centos_7
+    image: centos:7
+    command: /sbin/init
+    privileged: True
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: centos_8
+    image: centos:8
+    command: /sbin/init
+    privileged: True
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: ubuntu_16
+    image: ubuntu:16.04
+    command: /sbin/init
+    privileged: True
+  - name: ubuntu_18
+    image: ubuntu:18.04
+    command: /sbin/init
+    privileged: True
+  - name: debian_buster
+    image: debian:buster
+    command: /sbin/init
+    privileged: True
+  - name: debian_stretch
+    image: debian:stretch
+    command: /sbin/init
+    privileged: True
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+    enabled: false
+verifier:
+  name: testinfra
+  lint:
+    name: flake8
+    options:
+      ignore: 'E501'

--- a/roles/mongodb_auth/molecule/default/playbook.yml
+++ b/roles/mongodb_auth/molecule/default/playbook.yml
@@ -1,56 +1,35 @@
 ---
 - name: Converge
   hosts: all
+  become: yes
   vars:
-    # each machine is an isolated mongod instance
+    # for this test, each machine is an isolated mongod instance
     replicaset: false
     sharding: false
 
+  roles:
+    - mongodb_repository
+    - mongodb_mongod
+
   tasks:
-    - include_role:
-        name: mongodb_repository
-
-    - name: Install MongoDB Shell
-      package:
-        name: mongodb-org-shell
-
-    - name: Check mongo auth
-      raw: 'mongo admin --port 27017 --eval "db.getUsers()"'
-      # raw: 'mongo admin --port 27017 --username admin --password admin --eval "db.getUsers()"'
-      changed_when: no
-      failed_when: no
-
-    - include_role:
-        name: mongodb_mongod
-      vars:
-      # does bindIp=0.0.0.0 remove localhost exception?
-        bind_ip: 127.0.0.1
-
-    - name: Check mongo auth
-      raw: 'mongo admin --port 27017 --eval "db.getUsers()"'
-      # raw: 'mongo admin --port 27017 --username admin --password admin --eval "db.getUsers()"'
-      changed_when: no
-      failed_when: no
+    - name: Add EPEL repo to CentOS 7 to allow installing pip package
+      become: yes
+      yum:
+        name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts.distribution_major_version }}.noarch.rpm"
+        state: present
+      when: ansible_hostname == 'centos_7'
 
     - name: Install python stuff
       package:
-        name: ["python-setuptools", "python-pip"]
-
-    - name: Check mongo auth
-      raw: 'mongo admin --port 27017 --eval "db.getUsers()"'
-      # raw: 'mongo admin --port 27017 --username admin --password admin --eval "db.getUsers()"'
-      changed_when: no
-      failed_when: no
+        name:
+          - "python{% if needs_3 %}3{% endif %}-setuptools"
+          - "python{% if needs_3 %}3{% endif %}-pip"
+      vars:
+        needs_3: "{{ ansible_facts.python.version.major == 3 }}"
 
     - name: Install pymongo
       pip:
         name: pymongo
-
-    - name: Check mongo auth
-      raw: 'mongo admin --port 27017 --eval "db.getUsers()"'
-      # raw: 'mongo admin --port 27017 --username admin --password admin --eval "db.getUsers()"'
-      changed_when: no
-      failed_when: no
 
     - name: Enable mongo auth
       include_role:

--- a/roles/mongodb_auth/molecule/default/playbook.yml
+++ b/roles/mongodb_auth/molecule/default/playbook.yml
@@ -1,0 +1,57 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    # each machine is an isolated mongod instance
+    replicaset: false
+    sharding: false
+
+  tasks:
+    - include_role:
+        name: mongodb_repository
+
+    - name: Install MongoDB Shell
+      package:
+        name: mongodb-org-shell
+
+    - name: Check mongo auth
+      raw: 'mongo admin --port 27017 --eval "db.getUsers()"'
+      # raw: 'mongo admin --port 27017 --username admin --password admin --eval "db.getUsers()"'
+      changed_when: no
+      failed_when: no
+
+    - include_role:
+        name: mongodb_mongod
+      vars:
+      # does bindIp=0.0.0.0 remove localhost exception?
+        bind_ip: 127.0.0.1
+
+    - name: Check mongo auth
+      raw: 'mongo admin --port 27017 --eval "db.getUsers()"'
+      # raw: 'mongo admin --port 27017 --username admin --password admin --eval "db.getUsers()"'
+      changed_when: no
+      failed_when: no
+
+    - name: Install python stuff
+      package:
+        name: ["python-setuptools", "python-pip"]
+
+    - name: Check mongo auth
+      raw: 'mongo admin --port 27017 --eval "db.getUsers()"'
+      # raw: 'mongo admin --port 27017 --username admin --password admin --eval "db.getUsers()"'
+      changed_when: no
+      failed_when: no
+
+    - name: Install pymongo
+      pip:
+        name: pymongo
+
+    - name: Check mongo auth
+      raw: 'mongo admin --port 27017 --eval "db.getUsers()"'
+      # raw: 'mongo admin --port 27017 --username admin --password admin --eval "db.getUsers()"'
+      changed_when: no
+      failed_when: no
+
+    - name: Enable mongo auth
+      include_role:
+        name: mongodb_auth

--- a/roles/mongodb_auth/molecule/default/playbook.yml
+++ b/roles/mongodb_auth/molecule/default/playbook.yml
@@ -7,9 +7,34 @@
     replicaset: false
     sharding: false
 
+    # initially disable authorization on some hosts
+    hosts_with_auth_disabled:
+      - ubuntu_18
+      - debian_buster
+
+    # add some users for some of the hosts
+    hosts_with_extra_user:
+      - centos_8
+      - ubuntu_16
+      - debian_buster
+    mongodb_users_empty: []
+    mongodb_users_full:
+      - db: somedatabase
+        user: someuser
+        pwd: "S0meP@ss"
+        roles: readWrite
+      - db: somedatabase
+        user: otheruser
+        pwd: "0th3rP@ss"
+        roles: readWrite
+    mongodb_users: "{% if inventory_hostname in hosts_with_extra_user %}{{ mongodb_users_full }}{% else %}{{ mongodb_users_empty }}{% endif %}"
+
   roles:
-    - mongodb_repository
-    - mongodb_mongod
+    - role: mongodb_repository
+      tags: molecule-idempotence-notest
+    - role: mongodb_mongod
+      authorization: "{% if inventory_hostname in hosts_with_auth_disabled %}disabled{% else %}enabled{% endif %}"
+      tags: molecule-idempotence-notest # avoids false positive where replacing conf file disables authorization again
 
   tasks:
     - name: Add EPEL repo to CentOS 7 to allow installing pip package
@@ -17,7 +42,7 @@
       yum:
         name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts.distribution_major_version }}.noarch.rpm"
         state: present
-      when: ansible_hostname == 'centos_7'
+      when: inventory_hostname  == 'centos_7'
 
     - name: Install python stuff
       package:
@@ -34,3 +59,7 @@
     - name: Enable mongo auth
       include_role:
         name: mongodb_auth
+
+    - name: Install MongoDB Shell
+      package:
+        name: mongodb-org-shell

--- a/roles/mongodb_auth/molecule/default/tests/test_default.py
+++ b/roles/mongodb_auth/molecule/default/tests/test_default.py
@@ -1,0 +1,58 @@
+import os
+import yaml
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def include_vars(host):
+    ansible = host.ansible('include_vars',
+                           'file="../../defaults/main.yml"',
+                           False,
+                           False)
+    return ansible
+
+
+def test_mongod_cnf_file(host):
+    f = host.file('/etc/mongod.conf')
+
+    assert f.exists
+    assert yaml.safe_load(f.content)["security"]["authorization"] == "enabled"
+
+
+def test_mongod_service(host):
+    mongod_service = include_vars(host)['ansible_facts']['mongod_service']
+    s = host.service(mongod_service)
+
+    assert s.is_running
+    assert s.is_enabled
+
+
+def test_mongod_port(host):
+    try:
+        port = include_vars(host)['ansible_facts']['mongod_port']
+    except KeyError:
+        port = 27017
+    s = host.socket("tcp://0.0.0.0:{0}".format(port))
+    assert s.is_listening
+
+
+def test_mongod_replicaset(host):
+    '''
+    Ensure that the MongoDB replicaset has been created successfully
+    '''
+    try:
+        port = include_vars(host)['ansible_facts']['mongod_port']
+    except KeyError:
+        port = 27017
+    cmd = "mongo --port {0} --eval 'rs.status()'".format(port)
+    # We only want to run this once
+    if host.ansible.get_variables()['inventory_hostname'] == "ubuntu_16":
+        r = host.run(cmd)
+        assert "rs0" in r.stdout
+        assert "ubuntu_16:{0}".format(port) in r.stdout
+        assert "ubuntu_18:{0}".format(port) in r.stdout
+        assert "debian_stretch:{0}".format(port) in r.stdout

--- a/roles/mongodb_auth/molecule/virtualbox/molecule.yml
+++ b/roles/mongodb_auth/molecule/virtualbox/molecule.yml
@@ -1,0 +1,54 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+lint:
+  name: yamllint
+  options:
+    config-data:
+      line-length: disable
+platforms:
+  - name: centos-7
+    box: centos/7
+    interfaces:
+      - network_name: private_network
+        type: dhcp
+        auto_config: true
+  - name: ubuntu-16
+    box: ubuntu/xenial64
+    interfaces:
+      - network_name: private_network
+        type: dhcp
+        auto_config: true
+  - name: ubuntu-18
+    box: ubuntu/bionic64
+    interfaces:
+      - network_name: private_network
+        type: dhcp
+        auto_config: true
+  - name: debian-buster
+    box: debian/buster64
+    interfaces:
+      - network_name: private_network
+        type: dhcp
+        auto_config: true
+  - name: debian-stretch
+    box: debian/contrib-stretch64  # Standard debian/stretch64 had issues: Unable to locate package linux-headers-4.9.0-9-amd64
+    interfaces:
+      - network_name: private_network
+        type: dhcp
+        auto_config: true
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+    enabled: false
+verifier:
+  name: testinfra
+  lint:
+    name: flake8
+    options:
+      ignore: 'E501'

--- a/roles/mongodb_auth/molecule/virtualbox/playbook.yml
+++ b/roles/mongodb_auth/molecule/virtualbox/playbook.yml
@@ -2,18 +2,30 @@
 - name: Converge
   hosts: all
   become: yes
+  vars:
+    # for this test, each machine is an isolated mongod instance
+    replicaset: false
+    sharding: false
 
   roles:
-    - role: mongodb_repository
-    - role: mongodb_mongod
-      # each machine is an isolated mongod instance
-      replicaset: false
-      sharding: false
+    - mongodb_repository
+    - mongodb_mongod
 
   tasks:
+    - name: Add EPEL repo to CentOS 7 to allow installing pip package
+      become: yes
+      yum:
+        name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts.distribution_major_version }}.noarch.rpm"
+        state: present
+      when: ansible_hostname == 'centos_7'
+
     - name: Install python stuff
       package:
-        name: ["python-setuptools", "python-pip"]
+        name:
+          - "python{% if needs_3 %}3{% endif %}-setuptools"
+          - "python{% if needs_3 %}3{% endif %}-pip"
+      vars:
+        needs_3: "{{ ansible_facts.python.version.major == 3 }}"
 
     - name: Install pymongo
       pip:

--- a/roles/mongodb_auth/molecule/virtualbox/playbook.yml
+++ b/roles/mongodb_auth/molecule/virtualbox/playbook.yml
@@ -7,9 +7,35 @@
     replicaset: false
     sharding: false
 
+    # initially disable authorization on some hosts
+    hosts_with_auth_disabled:
+      - ubuntu_18
+      - debian_buster
+
+    # add some users for some of the hosts
+    hosts_with_extra_user:
+      - centos_8
+      - ubuntu_16
+      - debian_buster
+    mongodb_users_empty: []
+    mongodb_users_full:
+      - db: somedatabase
+        user: someuser
+        pwd: "S0meP@ss"
+        roles: readWrite
+      - db: somedatabase
+        user: otheruser
+        pwd: "0th3rP@ss"
+        roles: readWrite
+    mongodb_users: "{% if inventory_hostname in hosts_with_extra_user %}{{ mongodb_users_full }}{% else %}{{ mongodb_users_empty }}{% endif %}"
+
   roles:
-    - mongodb_repository
-    - mongodb_mongod
+    - role: mongodb_repository
+      tags: molecule-idempotence-notest
+    - role: mongodb_mongod
+      vars:
+        authorization: "{% if inventory_hostname in hosts_with_auth_disabled %}disabled{% else %}enabled{% endif %}"
+      tags: molecule-idempotence-notest # avoids false positive where replacing conf file disables authorization again
 
   tasks:
     - name: Add EPEL repo to CentOS 7 to allow installing pip package
@@ -17,7 +43,7 @@
       yum:
         name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts.distribution_major_version }}.noarch.rpm"
         state: present
-      when: ansible_hostname == 'centos_7'
+      when: inventory_hostname  == 'centos_7'
 
     - name: Install python stuff
       package:
@@ -34,3 +60,7 @@
     - name: Enable mongo auth
       include_role:
         name: mongodb_auth
+
+    - name: Install MongoDB Shell
+      package:
+        name: mongodb-org-shell

--- a/roles/mongodb_auth/molecule/virtualbox/playbook.yml
+++ b/roles/mongodb_auth/molecule/virtualbox/playbook.yml
@@ -1,0 +1,24 @@
+---
+- name: Converge
+  hosts: all
+  become: yes
+
+  roles:
+    - role: mongodb_repository
+    - role: mongodb_mongod
+      # each machine is an isolated mongod instance
+      replicaset: false
+      sharding: false
+
+  tasks:
+    - name: Install python stuff
+      package:
+        name: ["python-setuptools", "python-pip"]
+
+    - name: Install pymongo
+      pip:
+        name: pymongo
+
+    - name: Enable mongo auth
+      include_role:
+        name: mongodb_auth

--- a/roles/mongodb_auth/molecule/virtualbox/prepare.yml
+++ b/roles/mongodb_auth/molecule/virtualbox/prepare.yml
@@ -1,0 +1,36 @@
+---
+- name: Prepare
+  hosts: all
+  become: yes
+  vars:
+    avahi_packages_redhat:
+      - "avahi"
+      - "nss-mdns"
+    avahi_packages_debian:
+      - "avahi-daemon"
+      - "avahi-discover"
+      - "libnss-mdns"
+  tasks:
+
+  - name: Ensure epel is available
+    yum:
+      name: epel-release
+      state: present
+    when: ansible_os_family == "RedHat"
+
+  - name: Install avahi packages
+    package:
+      name: "{{ avahi_packages_redhat }}"
+      state: present
+    when: ansible_os_family == "RedHat"
+
+  - name: Install avahi packages
+    package:
+      name: "{{ avahi_packages_debian }}"
+      state: present
+    when: ansible_os_family == "Debian"
+
+  - name: Ensure avahi-daemon is restarted
+    service:
+      name: avahi-daemon
+      state: restarted

--- a/roles/mongodb_auth/molecule/virtualbox/tests/test_default.py
+++ b/roles/mongodb_auth/molecule/virtualbox/tests/test_default.py
@@ -1,0 +1,56 @@
+import os
+import yaml
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def include_vars(host):
+    ansible = host.ansible('include_vars',
+                           'file="../../defaults/main.yml"',
+                           False,
+                           False)
+    return ansible
+
+
+def test_mongod_cnf_file(host):
+    f = host.file('/etc/mongod.conf')
+
+    assert f.exists
+    assert yaml.safe_load(f.content)["security"]["authorization"] == "enabled"
+
+
+def test_mongod_service(host):
+    mongod_service = include_vars(host)['ansible_facts']['mongod_service']
+    s = host.service(mongod_service)
+
+    assert s.is_running
+    assert s.is_enabled
+
+
+def test_mongod_port(host):
+    port = include_vars(host)['ansible_facts']['mongod_port']
+    s = host.socket("tcp://0.0.0.0:{0}".format(port))
+
+    assert s.is_listening
+
+
+def test_mongod_replicaset(host):
+    '''
+    Ensure that the MongoDB replicaset has been created successfully
+    '''
+    port = include_vars(host)['ansible_facts']['mongod_port']
+    cmd = "mongo --port {0} --eval 'rs.status()'".format(port)
+    # We only want to run this once
+    if host.ansible.get_variables()['inventory_hostname'] == "ubuntu_16":
+        r = host.run(cmd)
+
+        assert "rs0" in r.stdout
+        assert "ubuntu-16:27017" in r.stdout
+        assert "ubuntu-18:27017" in r.stdout
+        assert "debian-stretch:27017" in r.stdout
+        assert "debian-buster:27017" in r.stdout
+        assert "centos-7:27017" in r.stdout

--- a/roles/mongodb_auth/molecule/virtualbox/tests/test_default.py
+++ b/roles/mongodb_auth/molecule/virtualbox/tests/test_default.py
@@ -4,12 +4,12 @@ import yaml
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']
-).get_hosts('all')
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
 
 
 def include_vars(host):
-    ansible = host.ansible('include_vars',
+    ansible = host.ansible("include_vars",
                            'file="../../defaults/main.yml"',
                            False,
                            False)
@@ -17,14 +17,14 @@ def include_vars(host):
 
 
 def test_mongod_cnf_file(host):
-    f = host.file('/etc/mongod.conf')
+    f = host.file("/etc/mongod.conf")
 
     assert f.exists
     assert yaml.safe_load(f.content)["security"]["authorization"] == "enabled"
 
 
 def test_mongod_service(host):
-    mongod_service = include_vars(host)['ansible_facts']['mongod_service']
+    mongod_service = include_vars(host)["ansible_facts"].get("mongod_service", "mongod")
     s = host.service(mongod_service)
 
     assert s.is_running
@@ -32,25 +32,25 @@ def test_mongod_service(host):
 
 
 def test_mongod_port(host):
-    port = include_vars(host)['ansible_facts']['mongod_port']
+    port = include_vars(host)["ansible_facts"].get("mongod_port", 27017)
     s = host.socket("tcp://0.0.0.0:{0}".format(port))
-
     assert s.is_listening
 
 
-def test_mongod_replicaset(host):
-    '''
-    Ensure that the MongoDB replicaset has been created successfully
-    '''
-    port = include_vars(host)['ansible_facts']['mongod_port']
-    cmd = "mongo --port {0} --eval 'rs.status()'".format(port)
-    # We only want to run this once
-    if host.ansible.get_variables()['inventory_hostname'] == "ubuntu_16":
-        r = host.run(cmd)
+def test_mongo_shell_connectivity(host):
+    """
+    Tests that we can connect to mongos via the shell annd run a cmd
+    """
+    facts = include_vars(host)["ansible_facts"]
+    port = facts.get("mongod_port", 27017)
+    user = facts.get("mongod_admin_user", "admin")
+    pwd = facts.get("mongod_default_admin_pwd", "admin")
 
-        assert "rs0" in r.stdout
-        assert "ubuntu-16:27017" in r.stdout
-        assert "ubuntu-18:27017" in r.stdout
-        assert "debian-stretch:27017" in r.stdout
-        assert "debian-buster:27017" in r.stdout
-        assert "centos-7:27017" in r.stdout
+    cmd = host.run(
+        "mongo admin --username {user} --password {pwd} --port {port} --eval 'db.runCommand({{listDatabases: 1}})'".format(
+            user=user, pwd=pwd, port=port
+        )
+    )
+
+    assert cmd.rc == 0
+    assert "admin" in cmd.stdout

--- a/roles/mongodb_auth/tasks/main.yml
+++ b/roles/mongodb_auth/tasks/main.yml
@@ -44,6 +44,8 @@
     login_host: localhost
     login_port: "{{ mongod_port | string }}"  # silence implicit int->str conversion warning
     create_for_localhost_exception: /root/mongodb_admin.success
+  module_defaults:
+    community.mongodb.mongodb_user: {}
 
 - name: Enable security section in mongod.conf
   lineinfile:

--- a/roles/mongodb_auth/tasks/main.yml
+++ b/roles/mongodb_auth/tasks/main.yml
@@ -29,11 +29,6 @@
   debug:
     msg: "[WARNING] Using default admin credentials for mongodb admin account! Please change them!"
 
-- name: Has MongoDB Admin User been created already?
-  stat:
-    path: /root/mongodb_admin.success
-  register: _mongodb_admin
-
 - name: Add mongo admin user with localhost exception
   community.mongodb.mongodb_user:
     state: present
@@ -48,9 +43,7 @@
 
     login_host: localhost
     login_port: "{{ mongod_port | string }}"  # silence implicit int->str conversion warning
-  # this will error when users are already configured outside of this role.
-  ignore_errors: yes
-  when: not _mongodb_admin.stat.exists
+    create_for_localhost_exception: /root/mongodb_admin.success
 
 - name: Enable security section in mongod.conf
   lineinfile:
@@ -88,24 +81,6 @@
   service:
     name: mongod
     state: restarted
-
-- name: Test mongo auth credentials
-  community.mongodb.mongodb_info:
-    login_user: "{{ mongodb_admin_user }}"
-    login_password: "{{ mongodb_admin_pwd }}"
-    login_database: admin
-    login_host: localhost
-    login_port: "{{ mongod_port | string }}"
-    filter: '!parameters'
-  register: _mongodb_info
-
-- name: Signal that MongoDB Admin User has been created
-  file:
-    state: touch
-    path: /root/mongodb_admin.success
-  when:
-    - not _mongodb_admin.stat.exists
-    - _mongodb_info is succeeded
 
 - name: Add additional mongo users
   include_tasks: mongodb_auth_user.yml

--- a/roles/mongodb_auth/tasks/main.yml
+++ b/roles/mongodb_auth/tasks/main.yml
@@ -1,0 +1,109 @@
+---
+# tasks file for mongodb_auth
+- name: Ensure mongod and pyyaml packages are installed
+  become: yes
+  package:
+    name:
+      - "{{ mongod_package }}"
+      - "{{ mongodb_shell_package }}"
+      # pyyaml is used to validate yaml files on change
+      - "{% if ansible_facts.os_family == 'RedHat' %}PyYAML{% else %}python-yaml{% endif %}"
+  register: _pkg
+  until: _pkg is succeeded
+  retries: 5
+
+- name: See if mongodb authorization is enabled and users are configured
+  command: 'mongo admin --port {{ mongod_port }} --eval "db.getUsers()"'
+  # this will fail (rc 252) if auth is enabled and users are configured
+  # With the localhost exception, this will succeed (rc 0) when users are not configured even if auth is enabled.
+  # see:
+  #   - https://docs.mongodb.com/manual/core/security-users/#localhost-exception
+  #   - https://stackoverflow.com/q/31949586/1134951
+  #   - https://github.com/ansible/ansible/issues/33832#issuecomment-358031733
+  register: _mongo_authorization
+  changed_when: no # this does not change anything, it only checks
+  failed_when: no # The rc determines whether or not auth is required to create/update the admin user
+
+- name: Show mongodb auth check output
+  # the purpose of this task is to make sure task output is visible in travis if there are problems
+  debug:
+    var: _mongo_authorization
+    verbosity: 2
+
+- name: Warn about default credentials
+  when: mongodb_admin_pwd == mongodb_default_admin_pwd
+  debug:
+    msg: "[WARNING] Using default admin credentials for mongodb admin account! Please change them!"
+
+- name: Add mongo admin
+  community.mongodb.mongodb_user:
+    state: present
+
+    # NOTE: on_create is idempotent - see comment below
+    # Also, on_create is required to use localhost exception.
+    update_password: on_create
+
+    name: "{{ mongodb_admin_user }}"
+    password: "{{ mongodb_admin_pwd }}"
+    database: "{{ mongodb_admin_db }}"
+    # roles: userAdminAnyDatabase
+    roles: "root"
+
+    # This does NOT include the mongo_auth_user.yml because of the
+    # special omit handling of login_* when mongo auth is not enabled/configured
+    # login_host: "{{ mongod_host }}"
+    login_port: "{{ mongod_port | string }}"  # silence implicit int->str conversion warning
+    # login_user: "{{ (_mongo_authorization.rc == 0) | ternary(omit, mongodb_admin_user) }}"
+    # login_password: "{{ (_mongo_authorization.rc == 0) | ternary(omit, mongodb_admin_pwd) }}"
+    # login_database: "{{ (_mongo_authorization.rc == 0) | ternary(omit, mongodb_admin_db) }}"
+
+- name: Enable security section in mongod.conf
+  become: yes
+  lineinfile:
+    path: /etc/mongod.conf
+    regexp: |-
+      ^[#'"\s]*security['"]?\s*:
+    line: 'security:'
+    validate: |
+      {{ mongodb_python }} -c '
+      import yaml, io
+      if "security" not in yaml.safe_load(io.open("%s")):
+          exit(1)
+      '
+
+- name: Enable authentication in mongod.conf
+  become: yes
+  lineinfile:
+    path: /etc/mongod.conf
+    insertafter: '^security:'
+    # two space indentation (the default) assumed
+    line: '  authorization: {{ authorization }}'
+    regexp: |-
+      ^[#'"\s]+authorization['"]?\s*:
+    validate: |
+      {{ mongodb_python }} -c '
+      import yaml, io
+      if yaml.safe_load(io.open("%s"))["security"]["authorization"] != "{{ authorization }}":
+          exit(1)
+      '
+  register: _enable_mongo_auth
+
+# This is a task instead of a handler so we can add users right away
+- name: Restart mongodb to enable auth before adding additional users
+  # This allows us to safely assume auth is already enabled when adding more users
+  when:
+    - mongodb_users | bool
+    - _enable_mongo_auth is changed
+  become: yes
+  service:
+    name: mongod
+    state: restarted
+
+- name: Add additional mongo users
+  include_tasks: mongodb_auth_user.yml
+  loop: "{{ mongodb_users }}"
+  loop_control:
+    loop_var: _mongodb_user
+  # using loop_control: label does not obscure the password in output for verbosity > 1
+  # So, loop over an include where the task name will include the username + db, but the loop var won't print out.
+  no_log: yes

--- a/roles/mongodb_auth/tasks/main.yml
+++ b/roles/mongodb_auth/tasks/main.yml
@@ -1,64 +1,58 @@
 ---
 # tasks file for mongodb_auth
+- name: Include OS-specific vars
+  include_vars:
+    file: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      paths:
+        - "vars"
+      files:
+        - "{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_version }}.yml"
+        - "{{ ansible_facts.os_family }}-{{ ansible_facts.distribution_major_version }}.yml"
+        - "{{ ansible_facts.distribution }}.yml"
+        - "{{ ansible_facts.os_family }}.yml"
+        - default.yml
+
 - name: Ensure mongod and pyyaml packages are installed
-  become: yes
   package:
     name:
       - "{{ mongod_package }}"
-      - "{{ mongodb_shell_package }}"
       # pyyaml is used to validate yaml files on change
-      - "{% if ansible_facts.os_family == 'RedHat' %}PyYAML{% else %}python-yaml{% endif %}"
+      - "{{ pyyaml_package }}"
   register: _pkg
   until: _pkg is succeeded
   retries: 5
-
-- name: See if mongodb authorization is enabled and users are configured
-  command: 'mongo admin --port {{ mongod_port }} --eval "db.getUsers()"'
-  # this will fail (rc 252) if auth is enabled and users are configured
-  # With the localhost exception, this will succeed (rc 0) when users are not configured even if auth is enabled.
-  # see:
-  #   - https://docs.mongodb.com/manual/core/security-users/#localhost-exception
-  #   - https://stackoverflow.com/q/31949586/1134951
-  #   - https://github.com/ansible/ansible/issues/33832#issuecomment-358031733
-  register: _mongo_authorization
-  changed_when: no # this does not change anything, it only checks
-  failed_when: no # The rc determines whether or not auth is required to create/update the admin user
-
-- name: Show mongodb auth check output
-  # the purpose of this task is to make sure task output is visible in travis if there are problems
-  debug:
-    var: _mongo_authorization
-    verbosity: 2
 
 - name: Warn about default credentials
   when: mongodb_admin_pwd == mongodb_default_admin_pwd
   debug:
     msg: "[WARNING] Using default admin credentials for mongodb admin account! Please change them!"
 
-- name: Add mongo admin
+- name: Has MongoDB Admin User been created already?
+  stat:
+    path: /root/mongodb_admin.success
+  register: _mongodb_admin
+
+- name: Add mongo admin user with localhost exception
   community.mongodb.mongodb_user:
     state: present
 
-    # NOTE: on_create is idempotent - see comment below
-    # Also, on_create is required to use localhost exception.
-    update_password: on_create
+    # on_create triggers additional queries that are not compatible with localhost exception
+    update_password: always
 
     name: "{{ mongodb_admin_user }}"
     password: "{{ mongodb_admin_pwd }}"
-    database: "{{ mongodb_admin_db }}"
-    # roles: userAdminAnyDatabase
-    roles: "root"
+    database: admin
+    roles: "{{ mongodb_admin_roles }}"
 
-    # This does NOT include the mongo_auth_user.yml because of the
-    # special omit handling of login_* when mongo auth is not enabled/configured
-    # login_host: "{{ mongod_host }}"
+    login_host: localhost
     login_port: "{{ mongod_port | string }}"  # silence implicit int->str conversion warning
-    # login_user: "{{ (_mongo_authorization.rc == 0) | ternary(omit, mongodb_admin_user) }}"
-    # login_password: "{{ (_mongo_authorization.rc == 0) | ternary(omit, mongodb_admin_pwd) }}"
-    # login_database: "{{ (_mongo_authorization.rc == 0) | ternary(omit, mongodb_admin_db) }}"
+  # this will error when users are already configured outside of this role.
+  ignore_errors: yes
+  when: not _mongodb_admin.stat.exists
 
 - name: Enable security section in mongod.conf
-  become: yes
   lineinfile:
     path: /etc/mongod.conf
     regexp: |-
@@ -72,7 +66,6 @@
       '
 
 - name: Enable authentication in mongod.conf
-  become: yes
   lineinfile:
     path: /etc/mongod.conf
     insertafter: '^security:'
@@ -91,13 +84,28 @@
 # This is a task instead of a handler so we can add users right away
 - name: Restart mongodb to enable auth before adding additional users
   # This allows us to safely assume auth is already enabled when adding more users
-  when:
-    - mongodb_users | bool
-    - _enable_mongo_auth is changed
-  become: yes
+  when: _enable_mongo_auth is changed
   service:
     name: mongod
     state: restarted
+
+- name: Test mongo auth credentials
+  community.mongodb.mongodb_info:
+    login_user: "{{ mongodb_admin_user }}"
+    login_password: "{{ mongodb_admin_pwd }}"
+    login_database: admin
+    login_host: localhost
+    login_port: "{{ mongod_port | string }}"
+    filter: '!parameters'
+  register: _mongodb_info
+
+- name: Signal that MongoDB Admin User has been created
+  file:
+    state: touch
+    path: /root/mongodb_admin.success
+  when:
+    - not _mongodb_admin.stat.exists
+    - _mongodb_info is succeeded
 
 - name: Add additional mongo users
   include_tasks: mongodb_auth_user.yml

--- a/roles/mongodb_auth/tasks/mongodb_auth_user.yml
+++ b/roles/mongodb_auth/tasks/mongodb_auth_user.yml
@@ -22,4 +22,4 @@
     login_port: "{{ mongod_port | string }}"  # silence implicit int->str conversion warning
     login_user: "{{ mongodb_admin_user }}"
     login_password: "{{ mongodb_admin_pwd }}"
-    login_database: "{{ mongodb_admin_db }}"
+    login_database: admin

--- a/roles/mongodb_auth/tasks/mongodb_auth_user.yml
+++ b/roles/mongodb_auth/tasks/mongodb_auth_user.yml
@@ -18,8 +18,8 @@
     database: "{{ _mongodb_user.db }}"
     roles: "{{ _mongodb_user.roles|default('readWrite') }}"
 
-    login_host: "{{ mongod_host }}"
-    login_port: "{{ mongod_port }}"
+    login_host: localhost
+    login_port: "{{ mongod_port | string }}"  # silence implicit int->str conversion warning
     login_user: "{{ mongodb_admin_user }}"
     login_password: "{{ mongodb_admin_pwd }}"
     login_database: "{{ mongodb_admin_db }}"

--- a/roles/mongodb_auth/tasks/mongodb_auth_user.yml
+++ b/roles/mongodb_auth/tasks/mongodb_auth_user.yml
@@ -1,0 +1,25 @@
+---
+- name: "Add mongo auth user - {{ _mongodb_user.user }} on {{ _mongodb_user.db }}"
+  community.mongodb.mongodb_user:
+    state: present
+
+    # NOTE: on_create is idempotent, always is not.
+    # With `update_password: on_create`, mongodb_user checks to see if the user
+    # (a) exists on the db, and (b) has the same roles,
+    # and then it only adds the user if it's not there or the roles have changed.
+    # With `update_password: always`, mongodb_user cannot tell if the password
+    # needs to be changed without attempting a login with those credentials.
+    # But mongodb_user does not currently implement such a check.
+    # A comment in mongodb_user points to https://jira.mongodb.org/browse/SERVER-22848
+    update_password: "{{ mongodb_force_update_password|ternary('always', 'on_create') }}"
+
+    name: "{{ _mongodb_user.user }}"
+    password: "{{ _mongodb_user.pwd }}"
+    database: "{{ _mongodb_user.db }}"
+    roles: "{{ _mongodb_user.roles|default('readWrite') }}"
+
+    login_host: "{{ mongod_host }}"
+    login_port: "{{ mongod_port }}"
+    login_user: "{{ mongodb_admin_user }}"
+    login_password: "{{ mongodb_admin_pwd }}"
+    login_database: "{{ mongodb_admin_db }}"

--- a/roles/mongodb_auth/tasks/mongodb_auth_user.yml
+++ b/roles/mongodb_auth/tasks/mongodb_auth_user.yml
@@ -23,3 +23,7 @@
     login_user: "{{ mongodb_admin_user }}"
     login_password: "{{ mongodb_admin_pwd }}"
     login_database: admin
+  # to provide additional auth details (eg for ssl* or auth_mechanism, set module_defaults in playbook)
+  # module_defaults:
+  #   community.mongodb.mongodb_user:
+  #      auth_mechanism: ...

--- a/roles/mongodb_auth/vars/RedHat-7.yml
+++ b/roles/mongodb_auth/vars/RedHat-7.yml
@@ -1,0 +1,2 @@
+---
+pyyaml_package: PyYAML

--- a/roles/mongodb_auth/vars/RedHat-8.yml
+++ b/roles/mongodb_auth/vars/RedHat-8.yml
@@ -1,0 +1,2 @@
+---
+pyyaml_package: python3-pyyaml

--- a/roles/mongodb_auth/vars/default.yml
+++ b/roles/mongodb_auth/vars/default.yml
@@ -1,0 +1,2 @@
+---
+pyyaml_package: "python{% if ansible_facts.python.version.major == 3 %}3{% endif %}-yaml"

--- a/roles/mongodb_auth/vars/main.yml
+++ b/roles/mongodb_auth/vars/main.yml
@@ -1,0 +1,5 @@
+---
+# The admin database, used to add users
+mongodb_admin_db: admin
+
+mongodb_python: "{{ ansible_python_interpreter | default( (ansible_python|default({})).get('executable', 'python') ) }}"

--- a/roles/mongodb_auth/vars/main.yml
+++ b/roles/mongodb_auth/vars/main.yml
@@ -1,5 +1,2 @@
 ---
-# The admin database, used to add users
-mongodb_admin_db: admin
-
 mongodb_python: "{{ ansible_python_interpreter | default( (ansible_python|default({})).get('executable', 'python') ) }}"

--- a/roles/mongodb_config/templates/configsrv.conf.j2
+++ b/roles/mongodb_config/templates/configsrv.conf.j2
@@ -31,8 +31,8 @@ net:
 
 {% if authorization == "enabled" %}
 security:
-    authorization: {{ authorization }}
-    keyFile: /etc/keyfile
+  authorization: {{ authorization }}
+  keyFile: /etc/keyfile
 {% endif %}
 
 #operationProfiling:

--- a/roles/mongodb_mongod/templates/mongod.conf.j2
+++ b/roles/mongodb_mongod/templates/mongod.conf.j2
@@ -35,7 +35,9 @@ net:
 {% if authorization == "enabled" %}
 security:
     authorization: {{ authorization }}
+{% if replicaset or sharding %}
     keyFile: /etc/keyfile
+{% endif %}
 {% endif %}
 
 #operationProfiling:

--- a/roles/mongodb_mongod/templates/mongod.conf.j2
+++ b/roles/mongodb_mongod/templates/mongod.conf.j2
@@ -34,9 +34,9 @@ net:
 
 {% if authorization == "enabled" %}
 security:
-    authorization: {{ authorization }}
+  authorization: {{ authorization }}
 {% if replicaset or sharding %}
-    keyFile: /etc/keyfile
+  keyFile: /etc/keyfile
 {% endif %}
 {% endif %}
 

--- a/roles/mongodb_mongos/templates/mongos.conf.j2
+++ b/roles/mongodb_mongos/templates/mongos.conf.j2
@@ -11,4 +11,4 @@ sharding:
 processManagement:
   timeZoneInfo: /usr/share/zoneinfo
 security:
-    keyFile: /etc/keyfile
+  keyFile: /etc/keyfile

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,3 +1,5 @@
+roles/mongodb_auth/molecule/default/tests/test_default.py future-import-boilerplate
+roles/mongodb_auth/molecule/virtualbox/tests/test_default.py future-import-boilerplate
 roles/mongodb_config/molecule/default/tests/test_default.py future-import-boilerplate
 roles/mongodb_config/molecule/virtualbox/tests/test_default.py future-import-boilerplate
 roles/mongodb_install/molecule/default/tests/test_default.py future-import-boilerplate
@@ -13,6 +15,8 @@ roles/mongodb_repository/molecule/default/tests/test_default.py future-import-bo
 roles/mongodb_repository/molecule/virtualbox/tests/test_default.py future-import-boilerplate
 roles/mongodb_selinux/molecule/default/tests/test_default.py future-import-boilerplate
 roles/mongodb_selinux/molecule/virtualbox/tests/test_default.py future-import-boilerplate
+roles/mongodb_auth/molecule/default/tests/test_default.py metaclass-boilerplate
+roles/mongodb_auth/molecule/virtualbox/tests/test_default.py metaclass-boilerplate
 roles/mongodb_config/molecule/default/tests/test_default.py metaclass-boilerplate
 roles/mongodb_config/molecule/virtualbox/tests/test_default.py metaclass-boilerplate
 roles/mongodb_install/molecule/default/tests/test_default.py metaclass-boilerplate

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,3 +1,5 @@
+roles/mongodb_auth/molecule/default/tests/test_default.py future-import-boilerplate
+roles/mongodb_auth/molecule/virtualbox/tests/test_default.py future-import-boilerplate
 roles/mongodb_config/molecule/default/tests/test_default.py future-import-boilerplate
 roles/mongodb_config/molecule/virtualbox/tests/test_default.py future-import-boilerplate
 roles/mongodb_install/molecule/default/tests/test_default.py future-import-boilerplate
@@ -13,6 +15,8 @@ roles/mongodb_repository/molecule/default/tests/test_default.py future-import-bo
 roles/mongodb_repository/molecule/virtualbox/tests/test_default.py future-import-boilerplate
 roles/mongodb_selinux/molecule/default/tests/test_default.py future-import-boilerplate
 roles/mongodb_selinux/molecule/virtualbox/tests/test_default.py future-import-boilerplate
+roles/mongodb_auth/molecule/default/tests/test_default.py metaclass-boilerplate
+roles/mongodb_auth/molecule/virtualbox/tests/test_default.py metaclass-boilerplate
 roles/mongodb_config/molecule/default/tests/test_default.py metaclass-boilerplate
 roles/mongodb_config/molecule/virtualbox/tests/test_default.py metaclass-boilerplate
 roles/mongodb_install/molecule/default/tests/test_default.py metaclass-boilerplate

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -4,6 +4,8 @@ plugins/modules/mongodb_shard.py use-argspec-type-path
 plugins/modules/mongodb_user.py use-argspec-type-path
 plugins/modules/mongodb_status.py use-argspec-type-path
 plugins/modules/mongodb_stepdown.py use-argspec-type-path
+roles/mongodb_auth/molecule/default/tests/test_default.py future-import-boilerplate
+roles/mongodb_auth/molecule/virtualbox/tests/test_default.py future-import-boilerplate
 roles/mongodb_config/molecule/default/tests/test_default.py future-import-boilerplate
 roles/mongodb_config/molecule/virtualbox/tests/test_default.py future-import-boilerplate
 roles/mongodb_install/molecule/default/tests/test_default.py future-import-boilerplate
@@ -19,6 +21,8 @@ roles/mongodb_repository/molecule/default/tests/test_default.py future-import-bo
 roles/mongodb_repository/molecule/virtualbox/tests/test_default.py future-import-boilerplate
 roles/mongodb_selinux/molecule/default/tests/test_default.py future-import-boilerplate
 roles/mongodb_selinux/molecule/virtualbox/tests/test_default.py future-import-boilerplate
+roles/mongodb_auth/molecule/default/tests/test_default.py metaclass-boilerplate
+roles/mongodb_auth/molecule/virtualbox/tests/test_default.py metaclass-boilerplate
 roles/mongodb_config/molecule/default/tests/test_default.py metaclass-boilerplate
 roles/mongodb_config/molecule/virtualbox/tests/test_default.py metaclass-boilerplate
 roles/mongodb_install/molecule/default/tests/test_default.py metaclass-boilerplate


### PR DESCRIPTION
##### SUMMARY
Add a new role to enable authentication on a random mongodb server.

Should handle:
- a server that does not have authentication enabled,
- a server that has auth enabled (or started with --auth) and localhost exception still applies, and
- a server that is already properly configured with auth enabled.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mongodb_auth role