### PR TITLE
Add create_for_localhost_exception parameter to mongodb_user module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv/*
 **/.DS_Store
+*.tar.gz

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -66,11 +66,13 @@ options:
     description:
       - C(always) will always update passwords and cause the module to return changed.
       - C(on_create) will only set the password for newly created users.
+      - This must be C(always) to use the localhost exception when adding the first admin user.
     type: str
 
 notes:
     - Requires the pymongo Python package on the remote host, version 2.4.2+. This
-      can be installed using pip or the OS package manager. @see http://api.mongodb.org/python/current/installation.html
+      can be installed using pip or the OS package manager. Newer mongo server versionss require newer 
+      pymongo versions. @see http://api.mongodb.org/python/current/installation.html
 requirements:
   - "pymongo"
 author:

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -400,7 +400,7 @@ def main():
                     client.close()
                 except Exception:
                     pass
-            module.exit_json(changed=False, user=user, skipped=True, msg="The path in create_for_localhost_exception exists.")
+                module.exit_json(changed=False, user=user, skipped=True, msg="The path in create_for_localhost_exception exists.")
 
         try:
             if update_password != 'always':

--- a/tests/integration/targets/mongodb_user/tasks/main.yml
+++ b/tests/integration/targets/mongodb_user/tasks/main.yml
@@ -53,6 +53,8 @@
     password: '{{ mongodb_admin_password }}'
     roles: root
     state: present
+    # TODO: an integration test with and without this. And a follow up test with this file that shows it skips
+    # create_for_localhost_exception: '{{ remote_tmp_dir }}/tests/admin_create.success'
   register: mongodb_admin_user_created
 - assert:
     that:

--- a/tests/integration/targets/mongodb_user/tasks/main.yml
+++ b/tests/integration/targets/mongodb_user/tasks/main.yml
@@ -3,16 +3,16 @@
     path: '{{ remote_tmp_dir }}/tests'
     state: directory
 
-- include_tasks: mongod_teardown.yml
-
-- set_fact:
-    current_replicaset: mongodb_user_tests_replicaset
-
 - set_fact:
     mongodb_nodes:
     - 3001
     - 3002
     - 3003
+
+- include_tasks: mongod_teardown.yml
+
+- set_fact:
+    current_replicaset: mongodb_user_tests_replicaset
 
 - include_tasks: mongod_replicaset.yml
 
@@ -59,21 +59,8 @@
 - assert:
     that:
     - mongodb_admin_user_created.changed == True
-- name: Kill all mongod processes
-  command: pkill  -{{ kill_signal }} mongod
-  ignore_errors: true
 
-- name: Getting pids for mongod
-  register: pids_of_mongod
-  community.general.pids:
-    name: mongod
-
-- name: Wait for all mongod processes to exit
-  wait_for:
-    path: /proc/{{ item }}/status
-    state: absent
-    delay: 3
-  with_items: '{{ pids_of_mongod }}'
+- include_tasks: mongod_stop.yml
 
 - set_fact:
     mongod_auth: true

--- a/tests/integration/targets/mongodb_user/tasks/main.yml
+++ b/tests/integration/targets/mongodb_user/tasks/main.yml
@@ -27,8 +27,6 @@
     password: '{{ mongodb_admin_password }}'
     roles: root
     state: present
-    # TODO: an integration test with and without this. And a follow up test with this file that shows it skips
-    # create_for_localhost_exception: '{{ remote_tmp_dir }}/tests/admin_create.success'
   register: mongodb_admin_user_created
 - assert:
     that:
@@ -182,5 +180,63 @@
 
 - debug:
     var: test_db_users
+
+- include_tasks: mongod_teardown.yml
+
+- set_fact:
+    current_replicaset: mongodb_user_test_localhost_exception_replicaset
+
+- set_fact:
+    mongod_auth: true
+
+- include_tasks: mongod_start_replicaset.yml
+
+- include_tasks: mongod_config_replicaset.yml
+
+- name: Check for absence of the create_for_localhost_exception file
+  stat:
+    path: '{{ remote_tmp_dir }}/tests/admin_create.success'
+  register: create_for_localhost_exception_file
+- assert:
+    that:
+    - not create_for_localhost_exception_file.stat.exists
+
+- name: Create admin user with module and create_for_localhost_exception
+  community.mongodb.mongodb_user:
+    login_port: 3001
+    replica_set: '{{ current_replicaset }}'
+    database: admin
+    name: '{{ mongodb_admin_user }}'
+    password: '{{ mongodb_admin_password }}'
+    roles: root
+    state: present
+    create_for_localhost_exception: '{{ remote_tmp_dir }}/tests/admin_create.success'
+  register: mongodb_admin_user_created
+- assert:
+    that:
+    - mongodb_admin_user_created is changed
+
+- name: Check for presence of the create_for_localhost_exception file
+  stat:
+    path: '{{ remote_tmp_dir }}/tests/admin_create.success'
+  register: create_for_localhost_exception_file
+- assert:
+    that:
+    - create_for_localhost_exception_file.stat.exists
+
+- name: Create admin when create_for_localhost_exception file exists
+  community.mongodb.mongodb_user:
+    login_port: 3001
+    replica_set: '{{ current_replicaset }}'
+    database: admin
+    name: '{{ mongodb_admin_user }}'
+    password: '{{ mongodb_admin_password }}'
+    roles: root
+    state: present
+    create_for_localhost_exception: '{{ remote_tmp_dir }}/tests/admin_create.success'
+  register: mongodb_admin_user_created
+- assert:
+    that:
+    - mongodb_admin_user_created is skipped
 
 - include_tasks: mongod_teardown.yml

--- a/tests/integration/targets/mongodb_user/tasks/main.yml
+++ b/tests/integration/targets/mongodb_user/tasks/main.yml
@@ -14,35 +14,9 @@
 - set_fact:
     current_replicaset: mongodb_user_tests_replicaset
 
-- include_tasks: mongod_replicaset.yml
+- include_tasks: mongod_start_replicaset.yml
 
-- name: Create current_replicaset with module
-  community.mongodb.mongodb_replicaset:
-    login_port: 3001
-    replica_set: '{{ current_replicaset }}'
-    members:
-    - localhost:3001
-    - localhost:3002
-    - localhost:3003
-
-- name: Check the status of the replicaset with mongodb_status module
-  community.mongodb.mongodb_status:
-    login_host: localhost
-    login_port: 3001
-    replica_set: '{{ current_replicaset }}'
-    poll: 99
-    interval: 10
-
-#- name: Ensure is_primary script exists on host
-#  copy:
-#    src: js/is_primary.js
-#    dest: '{{ remote_tmp_dir }}/tests/is_primary.js'
-
-#- name: Ensure host reaches primary before proceeding 3001
-#  command: mongo admin --port 3001 "{{ remote_tmp_dir }}/tests/is_primary.js"
-#  ignore_errors: yes
-
-#- command: cat "{{ remote_tmp_dir }}/mongod3001/log.log"  # Debug command
+- include_tasks: mongod_config_replicaset.yml
 
 - name: Create admin user with module
   community.mongodb.mongodb_user:
@@ -65,7 +39,7 @@
 - set_fact:
     mongod_auth: true
 
-- include_tasks: mongod_replicaset.yml
+- include_tasks: mongod_start_replicaset.yml
 
 - name: Check the status of the replicaset with mongodb_status module
   community.mongodb.mongodb_status:

--- a/tests/integration/targets/mongodb_user/tasks/mongod_config_replicaset.yml
+++ b/tests/integration/targets/mongodb_user/tasks/mongod_config_replicaset.yml
@@ -1,0 +1,29 @@
+---
+- name: Create current_replicaset with module
+  community.mongodb.mongodb_replicaset:
+    login_port: 3001
+    replica_set: '{{ current_replicaset }}'
+    members:
+    - localhost:3001
+    - localhost:3002
+    - localhost:3003
+
+- name: Check the status of the replicaset with mongodb_status module
+  community.mongodb.mongodb_status:
+    login_host: localhost
+    login_port: 3001
+    replica_set: '{{ current_replicaset }}'
+    poll: 99
+    interval: 10
+
+#- name: Ensure is_primary script exists on host
+#  copy:
+#    src: js/is_primary.js
+#    dest: '{{ remote_tmp_dir }}/tests/is_primary.js'
+
+#- name: Ensure host reaches primary before proceeding 3001
+#  command: mongo admin --port 3001 "{{ remote_tmp_dir }}/tests/is_primary.js"
+#  ignore_errors: yes
+
+#- command: cat "{{ remote_tmp_dir }}/mongod3001/log.log"  # Debug command
+

--- a/tests/integration/targets/mongodb_user/tasks/mongod_config_replicaset.yml
+++ b/tests/integration/targets/mongodb_user/tasks/mongod_config_replicaset.yml
@@ -26,4 +26,3 @@
 #  ignore_errors: yes
 
 #- command: cat "{{ remote_tmp_dir }}/mongod3001/log.log"  # Debug command
-

--- a/tests/integration/targets/mongodb_user/tasks/mongod_start_replicaset.yml
+++ b/tests/integration/targets/mongodb_user/tasks/mongod_start_replicaset.yml
@@ -1,3 +1,4 @@
+---
 - name: Set mongodb_user user for redhat
   set_fact:
     mongodb_user: mongod

--- a/tests/integration/targets/mongodb_user/tasks/mongod_stop.yml
+++ b/tests/integration/targets/mongodb_user/tasks/mongod_stop.yml
@@ -14,5 +14,3 @@
     state: absent
     delay: 3
   with_items: '{{ pids_of_mongod }}'
-
-

--- a/tests/integration/targets/mongodb_user/tasks/mongod_stop.yml
+++ b/tests/integration/targets/mongodb_user/tasks/mongod_stop.yml
@@ -1,0 +1,18 @@
+---
+- name: Kill all mongod processes
+  command: pkill  -{{ kill_signal }} mongod
+  ignore_errors: true
+
+- name: Getting pids for mongod
+  register: pids_of_mongod
+  community.general.pids:
+    name: mongod
+
+- name: Wait for all mongod processes to exit
+  wait_for:
+    path: /proc/{{ item }}/status
+    state: absent
+    delay: 3
+  with_items: '{{ pids_of_mongod }}'
+
+

--- a/tests/integration/targets/mongodb_user/tasks/mongod_teardown.yml
+++ b/tests/integration/targets/mongodb_user/tasks/mongod_teardown.yml
@@ -1,27 +1,11 @@
-- name: Kill all mongod processes
-  command: pkill  -{{ kill_signal }} mongod
-  ignore_errors: true
-
-- name: Getting pids for mongod
-  register: pids_of_mongod
-  community.general.pids:
-    name: mongod
-
-- name: Wait for all mongod processes to exit
-  wait_for:
-    path: /proc/{{ item }}/status
-    state: absent
-    delay: 1
-  with_items: '{{ pids_of_mongod }}'
+---
+- include_tasks: mongod_stop.yml
 
 - name: Remove all mongod folders
   file:
-    path: '{{ remote_tmp_dir }}/{{ item }}'
+    path: '{{ remote_tmp_dir }}/mongod{{ item }}'
     state: absent
-  with_items:
-  - mongod3001
-  - mongod3002
-  - mongod3003
+  with_items: '{{ mongodb_nodes }}'
 
 - name: Remove all mongod sock files
   shell: rm -Rf /tmp/mongodb*.sock


### PR DESCRIPTION
##### SUMMARY
Simplify touching a file after successfully creating the first admin user under the localhost exception.

Under the mongodb_mongos molecule playbooks, extra tasks handle checking for and touching the file

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mongodb_user module

##### ADDITIONAL INFORMATION
Simplify touching a file when creating an admin user with the localhost
exception. A pain point with the localhost exception is that you can't
tell if the first admin account has been added without attempting to
authenticate. So, provide a convenient helper that will touch the given
path when the user is successfully added.
    
Note that the name is long and unwieldy on purpose. This should be a
relatively uncommon use-case. When adding or updating most users, So, we
use the length as a signal to users that "this is not the parameter you
were looking for".