### PR TITLE
silence no_log warnings for update_password param

### DIFF
--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -307,7 +307,7 @@ def main():
         replica_set=dict(default=None),
         roles=dict(default=None, type='list', elements='raw'),
         state=dict(default='present', choices=['absent', 'present']),
-        update_password=dict(default="always", choices=["always", "on_create"])
+        update_password=dict(default="always", choices=["always", "on_create"], no_log=False)
     )
     module = AnsibleModule(
         argument_spec=argument_spec,


### PR DESCRIPTION


##### SUMMARY
Silence the warning about no_log by setting no_log to False
on the update_password param of the mongodb_user module.

This is what the warning looks like:
```
[WARNING]: Module did not set no_log for update_password
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mongodb_user module

##### ADDITIONAL INFORMATION
This takes the same approach as a postgresql module PR:
https://github.com/ansible/ansible/pull/68116
