### PR TITLE
Use molecule fork with travis log folding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
   - python --version
   - pip install --upgrade pip
   - export pyv=$(python -c 'from platform import python_version; print(python_version()[:3])')
+  - pip install 'git+git://github.com/cognifloyd/molecule@travis-folding-2.22#egg=molecule'
   - pip install --requirement requirements-${pyv}.txt
   - ansible-galaxy collection install community.general
   - ansible-galaxy collection build

--- a/requirements-2.7.txt
+++ b/requirements-2.7.txt
@@ -2,7 +2,7 @@ ansible==2.9.13
 ansible-lint==4.2.0
 docker==4.1.0
 flake8==3.7.9
-molecule==2.22
+molecule>=2.22,<3.0
 pytest==4.6.9
 python-vagrant==0.5.15
 # sh 1.13.1 causes molecule yamllint to fail.

--- a/requirements-3.5.txt
+++ b/requirements-3.5.txt
@@ -2,7 +2,7 @@ ansible==2.9.13
 ansible-lint==4.2.0
 docker==4.1.0
 flake8==3.7.9
-molecule==2.22
+molecule>=2.22,<3.0
 pytest==5.3.4
 python-vagrant==0.5.15
 sh==1.13.1

--- a/requirements-3.6.txt
+++ b/requirements-3.6.txt
@@ -2,7 +2,7 @@ ansible==2.9.13
 ansible-lint==4.2.0
 docker==4.1.0
 flake8==3.7.9
-molecule==2.22
+molecule>=2.22,<3.0
 pytest==5.3.4
 python-vagrant==0.5.15
 sh==1.13.1


### PR DESCRIPTION
##### SUMMARY
Enable molecule log folding in travis

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
travis-ci

##### ADDITIONAL INFORMATION
This branch is backported from https://github.com/ansible-community/molecule/pull/2851 on top of molecule 2.22.
It folds the different molecule actions in travis so it's easier to jump through what molecule is doing.

![Selection_090](https://user-images.githubusercontent.com/1558590/94834366-e7fd8100-03d5-11eb-8a37-88c11ddb2ce7.png)