### PR TITLE
Remove OS restriction from lookup_mongodb int tests

### DIFF
--- a/tests/integration/targets/lookup_mongodb/tasks/main.yml
+++ b/tests/integration/targets/lookup_mongodb/tasks/main.yml
@@ -18,7 +18,6 @@
 
 
 - include: test_lookup_mongo.yml
-  when: ansible_distribution == 'Ubuntu'
   vars:
     mongodb_parameters:
       #mandatory parameters


### PR DESCRIPTION
##### SUMMARY

Removes Ubuntu only restriction from lookup_mongodb integration tests.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tests/integration/targets/lookup_mongodb/tasks/main.yml
