### PR TITLE
Allow override mongod config for customization

### DIFF
--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -19,6 +19,7 @@ Role Variables
 * `mongod_package`: The mongod package to install. Default mongodb-org-server.
 * `replicaset`: When enabled add a replication section to the configuration. Default true.
 * `sharding`: If this replicaset member will form part of a sharded cluster. Default false.
+* `mongod_config_template`: If defined allows to override path to mongod config template with custom configuration. Default "mongod.conf.j2"
 
 IMPORTANT NOTE: It is expected that `mongodb_admin_user` & `mongodb_admin_pwd` values be overridden in your own file protected by Ansible Vault. These values are primary included here for Molecule/Travis CI integration. Any production environments should protect these values. For more information see [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 

--- a/roles/mongodb_mongod/tasks/main.yml
+++ b/roles/mongodb_mongod/tasks/main.yml
@@ -35,7 +35,7 @@
 
 - name: Copy config file
   template:
-    src: mongod.conf.j2
+    src: "{{ mongod_config_template }}"
     dest: /etc/mongod.conf
     owner: "{{ mongodb_user }}"
     group: "{{ mongodb_group }}"

--- a/roles/mongodb_mongod/vars/Debian.yml
+++ b/roles/mongodb_mongod/vars/Debian.yml
@@ -2,4 +2,5 @@
 mongodb_user: "mongodb"
 mongodb_group: "mongodb"
 mongod_service: "mongod"
+mongod_config_template: "mongod.conf.j2"
 db_path: /var/lib/mongodb

--- a/roles/mongodb_mongod/vars/RedHat.yml
+++ b/roles/mongodb_mongod/vars/RedHat.yml
@@ -2,4 +2,5 @@
 mongodb_user: "mongod"
 mongodb_group: "mongod"
 mongod_service: "mongod"
+mongod_config_template: "mongod.conf.j2"
 db_path: /var/lib/mongo

--- a/roles/mongodb_mongod/vars/default.yml
+++ b/roles/mongodb_mongod/vars/default.yml
@@ -2,4 +2,5 @@
 mongodb_user: "mongod"
 mongodb_group: "mongod"
 mongod_service: "mongod"
+mongod_config_template: "mongod.conf.j2"
 db_path: /var/lib/mongo


### PR DESCRIPTION
This should allow to override default config template and set any custom config that is required.
The idea is taken from https://github.com/geerlingguy/ansible-role-gitlab/pull/89
If you need custom config you can place template in `/templates` in the root ansible project folder with different name and set this name in `mongod_config_template` variable

In our case we need to be able to set `logRotate: reopen` for logrotate to work as expected. ﻿
