### PR TITLE
Various updates for mongodb_mongos virtualbox scenario

### DIFF
--- a/roles/mongodb_mongos/molecule/virtualbox/playbook.yml
+++ b/roles/mongodb_mongos/molecule/virtualbox/playbook.yml
@@ -50,6 +50,7 @@
           path: /etc/mongos.conf
           regexp: " *configDB: *"
           line: '  configDB: "cfg/config1.local:27019"'
+        when: "'config' not in ansible_hostname"
 
       - name: Restart the mongos service
         service:

--- a/roles/mongodb_mongos/molecule/virtualbox/prepare.yml
+++ b/roles/mongodb_mongos/molecule/virtualbox/prepare.yml
@@ -35,10 +35,14 @@
       state: present
     when: ansible_os_family == "Debian"
 
-  - name: Ensure services are restarted
+  # debian-stretch seems to require a reboot for avahi-daemon to run
+  - name: Reboot host
+    reboot:
+
+  - name: Ensure services are started
     service:
       name: "{{ item }}"
-      state: restarted
+      state: started
     with_items:
-      - dbus
+      #- dbus
       - avahi-daemon

--- a/roles/mongodb_mongos/molecule/virtualbox/tests/test_default.py
+++ b/roles/mongodb_mongos/molecule/virtualbox/tests/test_default.py
@@ -58,7 +58,7 @@ def test_mongos_shell_connectivity(host):
     '''
     if host.ansible.get_variables()['inventory_hostname'] != 'config1':
         port = include_vars(host)['ansible_facts']['mongos_port']
-        cmd = host.run("mongo admin --port {0} --eval 'db.runCommand({{listDatabases: 1}})'".format(port))
+        cmd = host.run("mongo admin -username admin --password admin --port {0} --eval 'db.runCommand({{listDatabases: 1}})'".format(port))
 
         assert cmd.rc == 0
         assert "config" in cmd.stdout


### PR DESCRIPTION
##### SUMMARY
A few updates for this role's virtualbox scenario including...

- Reboot host to get avahi-damon working on debian stretch.
- Filter out non mongos hosts as appropriate.
- Use auth with mongo shell test.


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
mongodb_mongos

