### PR TITLE
mongodb_config: Add reboot for avahi

### DIFF
--- a/roles/mongodb_config/molecule/virtualbox/prepare.yml
+++ b/roles/mongodb_config/molecule/virtualbox/prepare.yml
@@ -30,7 +30,10 @@
       state: present
     when: ansible_os_family == "Debian"
 
-  - name: Ensure avahi-daemon is restarted
+  - name: Reboot host for avahi-daemon
+    reboot:
+
+  - name: Ensure avahi-daemon is started
     service:
       name: avahi-daemon
-      state: restarted
+      state: started


### PR DESCRIPTION
##### SUMMARY
avahi not working. Added reboot seems to fix it (Debian stretch based distros)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mongodb_config
