### PR TITLE
Drop Python 2.7 and 3.5 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: python
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: python
 python:
-  - "3.5"
   - "3.6"
 env:
   jobs:


### PR DESCRIPTION
##### SUMMARY
Drop Python 2.7 and 3.5 from the Travis tests

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
.travis.yml

