### PR TITLE
Fix mongod_config_template override

### DIFF
--- a/roles/mongodb_config/defaults/main.yml
+++ b/roles/mongodb_config/defaults/main.yml
@@ -24,3 +24,4 @@ openssl_keyfile_content: |
   mJfrCUVuP1nBEklk23lYkNi/ohe+aodNjdN+2DHp42sGZHYP
 mongod_package: "mongodb-org-server"
 replicaset: true
+mongod_config_template: "configsrv.conf.j2"

--- a/roles/mongodb_config/vars/Debian.yml
+++ b/roles/mongodb_config/vars/Debian.yml
@@ -3,5 +3,4 @@ config_port: 27019
 mongodb_user: "mongodb"
 mongodb_group: "mongodb"
 mongod_service: "mongod"
-mongod_config_template: "configsrv.conf.j2"
 db_path: /var/lib/mongodb

--- a/roles/mongodb_config/vars/RedHat.yml
+++ b/roles/mongodb_config/vars/RedHat.yml
@@ -3,5 +3,4 @@ config_port: 27019
 mongodb_user: "mongod"
 mongodb_group: "mongod"
 mongod_service: "mongod"
-mongod_config_template: "configsrv.conf.j2"
 db_path: /var/lib/mongo

--- a/roles/mongodb_config/vars/default.yml
+++ b/roles/mongodb_config/vars/default.yml
@@ -3,5 +3,4 @@ config_port: 27019
 mongodb_user: "mongod"
 mongodb_group: "mongod"
 mongod_service: "mongod"
-mongod_config_template: "configsrv.conf.j2"
 db_path: /var/lib/mongo

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -26,3 +26,4 @@ mongodb_admin_pwd: admin
 mongod_package: "mongodb-org-server"
 replicaset: true
 sharding: false
+mongod_config_template: "mongod.conf.j2"

--- a/roles/mongodb_mongod/vars/Debian.yml
+++ b/roles/mongodb_mongod/vars/Debian.yml
@@ -2,5 +2,4 @@
 mongodb_user: "mongodb"
 mongodb_group: "mongodb"
 mongod_service: "mongod"
-mongod_config_template: "mongod.conf.j2"
 db_path: /var/lib/mongodb

--- a/roles/mongodb_mongod/vars/RedHat.yml
+++ b/roles/mongodb_mongod/vars/RedHat.yml
@@ -2,5 +2,4 @@
 mongodb_user: "mongod"
 mongodb_group: "mongod"
 mongod_service: "mongod"
-mongod_config_template: "mongod.conf.j2"
 db_path: /var/lib/mongo

--- a/roles/mongodb_mongod/vars/default.yml
+++ b/roles/mongodb_mongod/vars/default.yml
@@ -2,5 +2,4 @@
 mongodb_user: "mongod"
 mongodb_group: "mongod"
 mongod_service: "mongod"
-mongod_config_template: "mongod.conf.j2"
 db_path: /var/lib/mongo

--- a/roles/mongodb_mongos/defaults/main.yml
+++ b/roles/mongodb_mongos/defaults/main.yml
@@ -24,3 +24,4 @@ openssl_keyfile_content: |
   D3xVuE3WvrhldY5EOsaTt2ZXZx5REmJDIW1KcnvQKiVDJ2QzP5xdXYA0hh3TdTVE
   sb4UreMw/WyBpANiICMlJRBgSd0f0VGMlYzLX2BL14YpNnLhmoQqKzfBN6v2XAEG
   mJfrCUVuP1nBEklk23lYkNi/ohe+aodNjdN+2DHp42sGZHYP
+mongos_config_template: "mongos.conf.j2"

--- a/roles/mongodb_mongos/vars/Debian.yml
+++ b/roles/mongodb_mongos/vars/Debian.yml
@@ -2,5 +2,4 @@
 mongodb_user: "mongodb"
 mongodb_group: "mongodb"
 mongos_port: 27017
-mongos_config_template: "mongos.conf.j2"
 mongos_service: "mongos"

--- a/roles/mongodb_mongos/vars/RedHat.yml
+++ b/roles/mongodb_mongos/vars/RedHat.yml
@@ -2,5 +2,4 @@
 mongodb_user: "mongod"
 mongodb_group: "mongod"
 mongos_port: 27017
-mongos_config_template: "mongos.conf.j2"
 mongos_service: "mongos"

--- a/roles/mongodb_mongos/vars/default.yml
+++ b/roles/mongodb_mongos/vars/default.yml
@@ -2,5 +2,4 @@
 mongodb_user: "mongod"
 mongodb_group: "mongod"
 mongos_port: 27017
-mongos_config_template: "mongos.conf.j2"
 mongos_service: "mongos"


### PR DESCRIPTION
This PR relates to the fix I proposed recently https://github.com/ansible-collections/community.mongodb/pull/213
that was not fully tested by me. Please take my apologies, I'm not very good in Ansible-foo. 
Due to the way OS specific defaults are included into role, according to the Ansible docs the only way to override them is to specify it as extra_vars with -e cmd parameter so here I moved default template to the role defaults, this way one can override them in standard way if needed.
Hope this time all should work as expected, at least it works for me during local testing.

