### PR TITLE
Mongodb index example

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -22,3 +22,6 @@ repository: https://github.com/ansible-collections/community.mongodb
 documentation: https://github.com/ansible-collections/community.mongodb/tree/master/docs
 homepage: https://github.com/ansible-collections/community.mongodb
 issues: https://github.com/ansible-collections/community.mongodb
+build_ignore:
+  - tests
+  - '*.tar.gz'

--- a/plugins/modules/mongodb_index.py
+++ b/plugins/modules/mongodb_index.py
@@ -63,7 +63,7 @@ EXAMPLES = r'''
       - database: mydb
         collection: test
         options:
-          index_name: myindex
+          name: myindex
         state: absent
 
 - name: Create multiple indexes


### PR DESCRIPTION
##### SUMMARY
Correct mongodb_index example.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
mongodb_index

##### ADDITIONAL INFORMATION

The example specified an incorrect key name in the options dict: index_name -> index