### PR TITLE
CI: Remove mongodb_cache tests for Python 2.7

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -146,7 +146,6 @@ jobs:
     strategy:
       matrix:
         python_version:
-          - "2.7"
           - "3.5"
           - "3.8"
         ansible_version:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -22,3 +22,6 @@ repository: https://github.com/ansible-collections/community.mongodb
 documentation: https://github.com/ansible-collections/community.mongodb/tree/master/docs
 homepage: https://github.com/ansible-collections/community.mongodb
 issues: https://github.com/ansible-collections/community.mongodb
+build_ignore:
+  - tests
+  - '*.tar.gz'


### PR DESCRIPTION
##### SUMMARY
CI: Remove mongodb_cache tests for Python 2.7

##### ISSUE TYPE
- Feature Pull Request
- 
##### COMPONENT NAME
ansible-test.yml
