### PR TITLE
Update settings to get systemd working

### DIFF
--- a/roles/mongodb_install/molecule/default/molecule.yml
+++ b/roles/mongodb_install/molecule/default/molecule.yml
@@ -15,12 +15,20 @@ platforms:
     image: centos:8
   - name: ubuntu_16
     image: ubuntu:16.04
+    privileged: yes
+    command: "/sbin/init"
   - name: ubuntu_18
     image: ubuntu:18.04
+    privileged: yes
+    command: "/sbin/init"
   - name: debian_buster
     image: debian:buster
+    privileged: yes
+    command: "/sbin/init"
   - name: debian_stretch
     image: debian:stretch
+    privileged: yes
+    command: "/sbin/init"
 provisioner:
   name: ansible
   lint:


### PR DESCRIPTION
##### SUMMARY

Fixes broken systemd in Debian base containers. Adds privileged and command flag to molecule flag. Note moving the CMD line in the Dockerfile template did not work.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mongodb_install