### PR TITLE
Bump actions-setup-minikube to v2.3.0

### DIFF
--- a/.github/workflows/x509.yml
+++ b/.github/workflows/x509.yml
@@ -18,7 +18,7 @@ jobs:
           path: ansible_collections/community/mongodb
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.0.1
+        uses: manusa/actions-setup-minikube@v2.3.0
         with:
           minikube version: 'v1.13.1'
           kubernetes version: 'v1.19.2'


### PR DESCRIPTION
##### SUMMARY
Upgrade `manusa/actions-setup-minikube` to use the latest version.

GitHub is rolling out Ubuntu 20.04 as the default environment. GitHub actions workflows using `ubuntu-latest` will [soon ](https://github.com/actions/virtual-environments/issues/1816) start an Ubuntu 20,04 instance instead of 18.04.

Prior versions of `manusa/actions-setup-minikube` have a check which won't allow the workflow job to run. Starting on `2.2.0`, Ubuntu 20.04 is supported too (https://github.com/manusa/actions-setup-minikube/issues/26).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Dependency upgrade Pull Request

##### COMPONENT NAME
CI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
