### PR TITLE
Fix for idempotency

### DIFF
--- a/roles/mongodb_linux/tasks/main.yml
+++ b/roles/mongodb_linux/tasks/main.yml
@@ -82,12 +82,18 @@
     daemon_reexec: yes
   when: thp is changed
 
+- name: Check if disable-transparent-huge-pages service is already run
+  shell: cat /sys/kernel/mm/transparent_hugepage/enabled | grep -o "never"
+  register: _huge_page_status
+  ignore_errors: yes
+  changed_when: _huge_page_status.stdout == ""
+
 - name: Enable disable-transparent-huge-pages service
   service:
     name: disable-transparent-huge-pages
     state: started
     enabled: yes
-  when: not is_docker.stat.exists
+  when: (not is_docker.stat.exists) and (_huge_page_status.stdout == "")
 
 # Tasks based on: https://docs.mongodb.com/manual/reference/ulimit/
 


### PR DESCRIPTION
##### SUMMARY
The `disable-transparent-huge-pages.service` is a `oneshot` service.
So, when we try to ensure its status as `started`, it runs it
and reports a `changed` status. This means a playbook that uses
this role will always report a `changed` status. This is not good.

What we need to do instead is to check if the `disable-transparent-huge-pages.service`
has already run. If not then we run it or else we skip it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
role/mongodb_linux
