### PR TITLE
Update handlers and change default of skip_restart to true

### DIFF
--- a/roles/mongodb_config/README.md
+++ b/roles/mongodb_config/README.md
@@ -18,7 +18,7 @@ Role Variables
 * `mongod_package`: The name of the mongod installation package. Default mongodb-org-server.
 replicaset: When enabled add a replication section to the configuration. Default true.
 * `mongod_config_template`: If defined allows to override path to mongod config template with custom configuration. Default "mongod.conf.j2"
-* `skip_restart`: If set to `true` will skip restarting mongod service when config file or the keyfile content changes. Default `false`.
+* `skip_restart`: If set to `true` will skip restarting mongod service when config file or the keyfile content changes. Default `true`.
 
 Dependencies
 ------------

--- a/roles/mongodb_config/defaults/main.yml
+++ b/roles/mongodb_config/defaults/main.yml
@@ -25,4 +25,4 @@ openssl_keyfile_content: |
 mongod_package: "mongodb-org-server"
 replicaset: true
 mongod_config_template: "configsrv.conf.j2"
-skip_restart: false
+skip_restart: true

--- a/roles/mongodb_config/handlers/handlers.yml
+++ b/roles/mongodb_config/handlers/handlers.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Restart mongod service
+  service:
+    name: "{{ mongod_service }}"
+    state: restarted
+
+- name: Wait for port to become active
+  wait_for:
+    port: "{{ config_port }}"

--- a/roles/mongodb_config/handlers/main.yml
+++ b/roles/mongodb_config/handlers/main.yml
@@ -1,7 +1,5 @@
 ---
 
 - name: Restart mongod service
-  service:
-    name: "{{ mongod_service }}"
-    state: restarted
+  import_tasks: handlers.yml
   when: not skip_restart

--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -20,7 +20,7 @@ Role Variables
 * `replicaset`: When enabled add a replication section to the configuration. Default true.
 * `sharding`: If this replicaset member will form part of a sharded cluster. Default false.
 * `mongod_config_template`: If defined allows to override path to mongod config template with custom configuration. Default "mongod.conf.j2"
-* `skip_restart`: If set to `true` will skip restarting mongod service when config file or the keyfile content changes. Default `false`.
+* `skip_restart`: If set to `true` will skip restarting mongod service when config file or the keyfile content changes. Default `true`.
 
 IMPORTANT NOTE: It is expected that `mongodb_admin_user` & `mongodb_admin_pwd` values be overridden in your own file protected by Ansible Vault. These values are primary included here for Molecule/Travis CI integration. Any production environments should protect these values. For more information see [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -27,4 +27,4 @@ mongod_package: "mongodb-org-server"
 replicaset: true
 sharding: false
 mongod_config_template: "mongod.conf.j2"
-skip_restart: false
+skip_restart: true

--- a/roles/mongodb_mongod/handlers/handlers.yml
+++ b/roles/mongodb_mongod/handlers/handlers.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Restart mongod service
+  service:
+    name: "{{ mongod_service }}"
+    state: restarted
+
+- name: Wait for port to become active
+  wait_for:
+    port: "{{ mongod_port }}"

--- a/roles/mongodb_mongod/handlers/main.yml
+++ b/roles/mongodb_mongod/handlers/main.yml
@@ -1,7 +1,5 @@
 ---
 
 - name: Restart mongod service
-  service:
-    name: "{{ mongod_service }}"
-    state: restarted
+  import_tasks: handlers.yml
   when: not skip_restart

--- a/roles/mongodb_mongos/README.md
+++ b/roles/mongodb_mongos/README.md
@@ -25,7 +25,7 @@ Role Variables
 * `config_servers`: "config1:27019, config2:27019, config3:27019"
 * `openssl_keyfile_content`: The kexfile content that MongoDB uses to authenticate within a replicaset. Generate with cmd: openssl rand -base64 756.
 * `mongos_config_template`: If defined allows to override path to mongod config template with custom configuration. Default "mongos.conf.j2"
-* `skip_restart`: If set to `true` will skip restarting mongos service when config file or the keyfile content changes. Default `false`.
+* `skip_restart`: If set to `true` will skip restarting mongos service when config file or the keyfile content changes. Default `true`.
 
 Dependencies
 ------------

--- a/roles/mongodb_mongos/defaults/main.yml
+++ b/roles/mongodb_mongos/defaults/main.yml
@@ -25,4 +25,4 @@ openssl_keyfile_content: |
   sb4UreMw/WyBpANiICMlJRBgSd0f0VGMlYzLX2BL14YpNnLhmoQqKzfBN6v2XAEG
   mJfrCUVuP1nBEklk23lYkNi/ohe+aodNjdN+2DHp42sGZHYP
 mongos_config_template: "mongos.conf.j2"
-skip_restart: false
+skip_restart: true

--- a/roles/mongodb_mongos/handlers/handlers.yml
+++ b/roles/mongodb_mongos/handlers/handlers.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Restart mongod service
+- name: Restart mongos service
   service:
     name: "{{ mongos_service }}"
     state: restarted

--- a/roles/mongodb_mongos/handlers/handlers.yml
+++ b/roles/mongodb_mongos/handlers/handlers.yml
@@ -7,4 +7,4 @@
 
 - name: Wait for port to become active
   wait_for:
-    port: "{{ mongod_port }}"
+    port: "{{ mongos_port }}"

--- a/roles/mongodb_mongos/handlers/handlers.yml
+++ b/roles/mongodb_mongos/handlers/handlers.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Restart mongod service
+  service:
+    name: "{{ mongos_service }}"
+    state: restarted
+
+- name: Wait for port to become active
+  wait_for:
+    port: "{{ mongod_port }}"

--- a/roles/mongodb_mongos/handlers/main.yml
+++ b/roles/mongodb_mongos/handlers/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Restart mongos service
   import_tasks: handlers.yml
   when: not skip_restart

--- a/roles/mongodb_mongos/handlers/main.yml
+++ b/roles/mongodb_mongos/handlers/main.yml
@@ -1,7 +1,5 @@
 ---
 
 - name: Restart mongos service
-  service:
-    name: "{{ mongos_service }}"
-    state: restarted
+  import_tasks: handlers.yml
   when: not skip_restart


### PR DESCRIPTION
##### SUMMARY

Update handlers and change default of skip_restart to true. This puts the roles back to the previous way it worked. The restart causes issues with our units tests causing them to sometimes timeout.


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
mongodb_mongod
mongodb_config
mongodb_mongos
