### PR TITLE
Reformat mongodb_auth variables list

### DIFF
--- a/roles/mongodb_auth/README.md
+++ b/roles/mongodb_auth/README.md
@@ -14,16 +14,16 @@ when this role tries to add the admin user again.
 Role Variables
 --------------
 
-mongod_host: The domain or ip to use to communicate with mongod. Default localhost.
-mongod_port: The port used by the mongod process. Default 27017.
-mongod_package: The mongod package to install. Default mongodb-org-server.
-authorization: Enable authorization. Default enabled.
-mongodb_admin_db: MongoDB admin database (for adding users). Default admin.
-mongodb_admin_user: MongoDB admin username. Default admin.
-mongodb_admin_pwd: MongoDB admin password. Defaults to value of mongodb_admin_default_pwd.
-mongodb_admin_default_pwd: MongoDB admin password (for parent roles to override without overriding user's password). Default admin.
-mongodb_users: List of additional users to add. Each user dict should include fields: db, user, pwd, roles
-mongodb_force_update_password: Whether or not to force a password update for any users in mongodb_users. Setting this to yes will result in 'changed' on every run, even if the password is the same. Setting this to no only adds a password when creating the user.
+* `mongod_host`: The domain or ip to use to communicate with mongod. Default localhost.
+* `mongod_port`: The port used by the mongod process. Default 27017.
+* `mongod_package`: The mongod package to install. Default mongodb-org-server.
+* `authorization`: Enable authorization. Default enabled.
+* `mongodb_admin_db`: MongoDB admin database (for adding users). Default admin.
+* `mongodb_admin_user`: MongoDB admin username. Default admin.
+* `mongodb_admin_pwd`: MongoDB admin password. Defaults to value of mongodb_admin_default_pwd.
+* `mongodb_admin_default_pwd`: MongoDB admin password (for parent roles to override without overriding user's password). Default admin.
+* `mongodb_users`: List of additional users to add. Each user dict should include fields: db, user, pwd, roles
+* `mongodb_force_update_password`: Whether or not to force a password update for any users in mongodb_users. Setting this to yes will result in 'changed' on every run, even if the password is the same. Setting this to no only adds a password when creating the user.
 
 IMPORTANT NOTE: It is expected that mongodb_admin_user & mongodb_admin_pwd values be overridden in your own file protected by Ansible Vault. Any production environments should protect these values. For more information see [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 


### PR DESCRIPTION
##### SUMMARY
Reformat role variables list in mongodb_auth readme to follow overall style.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Role mongodb_auth

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Format role variables as mardown list
