### PR TITLE
Document roles & plugins in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,61 @@ As this is an independent collection, it can be released on its own release cade
 
 If you like this collection please give us a rating on [Ansible Galaxy](https://galaxy.ansible.com/community/mongodb).
 
+## Collection contents
+
+### Roles
+
+These roles prepare servers with Debian-based and RHEL-based distributions to run MongoDB:
+
+- `community.mongodb.mongodb_linux`: A simple role to configure Linux Operating System settings, as advised in the [MongoDB Production Notes](https://docs.mongodb.com/manual/administration/production-notes/).
+- `community.mongodb.mongodb_selinux`: Configure SELinux for MongoDB
+
+- `community.mongodb.mongodb_repository`: Configures a repository for MongoDB on Debian and RedHat based platforms.
+- `community.mongodb.mongodb_install`: Install MongoDB packages on Debian and RedHat based platforms. This role, unlike all other roles, provides for installing specific versions of mongodb. Other roles merely validate that mongodb-org is installed/present; they do not install particular versions.
+
+These roles manage configuring and starting various MongoDB services.
+
+- `community.mongodb.mongodb_mongod`: Configure the `mongod` service (includes populating `mongod.conf`) which is a MongoDB replicaset or standalone server.
+- `community.mongodb.mongodb_mongos`: Configure the `mongos` service (includes populating `mongos.conf`) which only runs in a sharded MongoDB cluster.
+- `community.mongodb.mongodb_config`: Configure the CSRS Config Server Replicaset for a MongoDB sharded cluster. The CSRS is a special-purpose instance of `mongod` that hosts the `config` database for the sharded cluster. For standalone installations, please use the `mongodb_mongod` role instead.
+- `community.mongodb.mongodb_auth`: Configure auth on MongoDB servers. NB: The other MongoDB server config roles (`mongodb_mongod`, `mongodb_mongos`, `mongodb_config`) do not configure auth. Use this role in conjunction with the other roles.
+
+### Plugins
+
+#### Lookup Plugins
+- `community.mongodb.mongodb`: A lookup plugin that gets info from a collection using the MongoDB `find()` function.
+
+#### Cache Plugins
+- `community.mongodb.mongodb`: A cache plugin that stores the host fact cache records in MongoDB.
+
+#### Modules
+
+These modules are for any MongoDB cluster (standalone, replicaset, or sharded):
+
+- `mongodb_index`: Creates or drops indexes on MongoDB collections.
+- `mongodb_info`: Gather information about MongoDB instance.
+- `mongodb_monitoring`: Manages the [free monitoring](https://docs.mongodb.com/manual/administration/free-monitoring/) feature.
+- `mongodb_oplog`: [Resizes](https://docs.mongodb.com/manual/tutorial/change-oplog-size) the MongoDB oplog (MongoDB 3.6+ only).
+- `mongodb_parameter`: Change an administrative parameter on a MongoDB server.
+- `mongodb_shell`: Run commands via the MongoDB shell.
+- `mongodb_shutdown`: Cleans up all database resources and then terminates the mongod/mongos process.
+- `mongodb_user`: 
+
+These modules are only useful for replicaset (or sharded) MongoDB clusters:
+
+- `mongodb_maintenance`: Enables or disables [maintenance](https://docs.mongodb.com/manual/reference/command/replSetMaintenance/) mode for a secondary member.
+- `mongodb_replicaset`: Initialises a MongoDB replicaset.
+- `mongodb_status`: Validates the status of the replicaset.
+- `mongodb_stepdown`: [Step down](https://docs.mongodb.com/manual/reference/command/replSetStepDown/) the MongoDB node from a PRIMARY state.
+
+These modules are only useful for sharded MongoDB clusters:
+
+- `mongodb_balancer`: Manages the MongoDB Sharded Cluster Balancer.
+- `mongodb_shard`: Add or remove shards from a MongoDB Cluster.
+- `mongodb_shard_tag`: Manage Shard Tags.
+- `mongodb_shard_zone`: Manage Shard Zones.
+
+
 ## Running the integration and unit tests
 
 * Requirements

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ These roles prepare servers with Debian-based and RHEL-based distributions to ru
 - `community.mongodb.mongodb_linux`: A simple role to configure Linux Operating System settings, as advised in the [MongoDB Production Notes](https://docs.mongodb.com/manual/administration/production-notes/).
 - `community.mongodb.mongodb_selinux`: Configure SELinux for MongoDB.
 
-- `community.mongodb.mongodb_repository`: Configures a repository for MongoDB on Debian and RedHat based platforms.
-- `community.mongodb.mongodb_install`: Install MongoDB packages on Debian and RedHat based platforms. This role, unlike all other roles, provides for installing specific versions of mongodb. Other roles merely validate that mongodb-org is installed/present; they do not install particular versions.
+- `community.mongodb.mongodb_repository`: Configures a package repository for MongoDB on Debian and RedHat based platforms.
+- `community.mongodb.mongodb_install`: Install MongoDB packages on Debian and RedHat based platforms. This role, unlike all other roles, provides for installing specific versions of mongodb-org packages. Other roles merely validate that mongodb-org is installed/present; they do not install particular versions.
 
 These roles manage configuring and starting various MongoDB services.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you like this collection please give us a rating on [Ansible Galaxy](https://
 These roles prepare servers with Debian-based and RHEL-based distributions to run MongoDB:
 
 - `community.mongodb.mongodb_linux`: A simple role to configure Linux Operating System settings, as advised in the [MongoDB Production Notes](https://docs.mongodb.com/manual/administration/production-notes/).
-- `community.mongodb.mongodb_selinux`: Configure SELinux for MongoDB
+- `community.mongodb.mongodb_selinux`: Configure SELinux for MongoDB.
 
 - `community.mongodb.mongodb_repository`: Configures a repository for MongoDB on Debian and RedHat based platforms.
 - `community.mongodb.mongodb_install`: Install MongoDB packages on Debian and RedHat based platforms. This role, unlike all other roles, provides for installing specific versions of mongodb. Other roles merely validate that mongodb-org is installed/present; they do not install particular versions.
@@ -46,28 +46,28 @@ These roles manage configuring and starting various MongoDB services.
 
 These modules are for any MongoDB cluster (standalone, replicaset, or sharded):
 
-- `mongodb_index`: Creates or drops indexes on MongoDB collections.
-- `mongodb_info`: Gather information about MongoDB instance.
-- `mongodb_monitoring`: Manages the [free monitoring](https://docs.mongodb.com/manual/administration/free-monitoring/) feature.
-- `mongodb_oplog`: [Resizes](https://docs.mongodb.com/manual/tutorial/change-oplog-size) the MongoDB oplog (MongoDB 3.6+ only).
-- `mongodb_parameter`: Change an administrative parameter on a MongoDB server.
-- `mongodb_shell`: Run commands via the MongoDB shell.
-- `mongodb_shutdown`: Cleans up all database resources and then terminates the mongod/mongos process.
-- `mongodb_user`: 
+- `community.mongodb.mongodb_index`: Creates or drops indexes on MongoDB collections.
+- `community.mongodb.mongodb_info`: Gather information about MongoDB instance.
+- `community.mongodb.mongodb_monitoring`: Manages the [free monitoring](https://docs.mongodb.com/manual/administration/free-monitoring/) feature.
+- `community.mongodb.mongodb_oplog`: [Resizes](https://docs.mongodb.com/manual/tutorial/change-oplog-size) the MongoDB oplog (MongoDB 3.6+ only).
+- `community.mongodb.mongodb_parameter`: Change an administrative parameter on a MongoDB server.
+- `community.mongodb.mongodb_shell`: Run commands via the MongoDB shell.
+- `community.mongodb.mongodb_shutdown`: Cleans up all database resources and then terminates the mongod/mongos process.
+- `community.mongodb.mongodb_user`: 
 
 These modules are only useful for replicaset (or sharded) MongoDB clusters:
 
-- `mongodb_maintenance`: Enables or disables [maintenance](https://docs.mongodb.com/manual/reference/command/replSetMaintenance/) mode for a secondary member.
-- `mongodb_replicaset`: Initialises a MongoDB replicaset.
-- `mongodb_status`: Validates the status of the replicaset.
-- `mongodb_stepdown`: [Step down](https://docs.mongodb.com/manual/reference/command/replSetStepDown/) the MongoDB node from a PRIMARY state.
+- `community.mongodb.mongodb_maintenance`: Enables or disables [maintenance](https://docs.mongodb.com/manual/reference/command/replSetMaintenance/) mode for a secondary member.
+- `community.mongodb.mongodb_replicaset`: Initialises a MongoDB replicaset.
+- `community.mongodb.mongodb_status`: Validates the status of the replicaset.
+- `community.mongodb.mongodb_stepdown`: [Step down](https://docs.mongodb.com/manual/reference/command/replSetStepDown/) the MongoDB node from a PRIMARY state.
 
 These modules are only useful for sharded MongoDB clusters:
 
-- `mongodb_balancer`: Manages the MongoDB Sharded Cluster Balancer.
-- `mongodb_shard`: Add or remove shards from a MongoDB Cluster.
-- `mongodb_shard_tag`: Manage Shard Tags.
-- `mongodb_shard_zone`: Manage Shard Zones.
+- `community.mongodb.mongodb_balancer`: Manages the MongoDB Sharded Cluster Balancer.
+- `community.mongodb.mongodb_shard`: Add or remove shards from a MongoDB Cluster.
+- `community.mongodb.mongodb_shard_tag`: Manage Shard Tags.
+- `community.mongodb.mongodb_shard_zone`: Manage Shard Zones.
 
 
 ## Running the integration and unit tests

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,8 @@ authors:
   - Elliott Foster (http://fourkitchens.com)
   - Loic Blot (http://www.infopro-digital.com/)
   - Matt Martz (https://github.com/sivel)
-description: null
+  - Jacob Floyd (https://github.com/cognifloyd)
+description: MongoDB related ansible Roles, Modules, and Plugins
 license_file: COPYING
 tags:
   - mongodb

--- a/roles/mongodb_auth/meta/main.yml
+++ b/roles/mongodb_auth/meta/main.yml
@@ -1,9 +1,9 @@
 ---
 galaxy_info:
   author: Jacob Floyd
-  description: Configure auth on MongoDB servers
+  description: Configure auth on MongoDB servers.
 
-  license: BSD
+  license: GPLv3
 
   min_ansible_version: 2.9
 

--- a/roles/mongodb_config/meta/main.yml
+++ b/roles/mongodb_config/meta/main.yml
@@ -1,8 +1,7 @@
 ---
 galaxy_info:
   author: Rhys Campbell
-  description: your description
-  company: your company (optional)
+  description: Configure the CSRS Config Server Replicaset for a MongoDB sharded cluster. (Use mongodb_mongod for Standalone installations - this does not create mongo.conf)
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -15,7 +14,7 @@ galaxy_info:
   # - GPLv3
   # - Apache
   # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
+  license: GPLv3
 
   min_ansible_version: 1.2
 

--- a/roles/mongodb_install/meta/main.yml
+++ b/roles/mongodb_install/meta/main.yml
@@ -1,8 +1,7 @@
 ---
 galaxy_info:
-  author: your name
-  description: your description
-  company: your company (optional)
+  author: Rhys Campbell
+  description: Install MongoDB packages on Debian and RedHat based platforms.
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -15,7 +14,7 @@ galaxy_info:
   # - GPLv3
   # - Apache
   # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
+  license: GPLv3
 
   min_ansible_version: 1.2
 

--- a/roles/mongodb_linux/meta/main.yml
+++ b/roles/mongodb_linux/meta/main.yml
@@ -1,8 +1,7 @@
 ---
 galaxy_info:
-  author: your name
-  description: your description
-  company: your company (optional)
+  author: Rhys Campbell
+  description: A simple role to configure Linux Operating System settings, as advised in the MongoDB Production Notes.
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -15,7 +14,7 @@ galaxy_info:
   # - GPLv3
   # - Apache
   # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
+  license: GPLv3
 
   min_ansible_version: 1.2
 

--- a/roles/mongodb_mongod/meta/main.yml
+++ b/roles/mongodb_mongod/meta/main.yml
@@ -1,8 +1,7 @@
 ---
 galaxy_info:
   author: Rhys Campbell
-  description: your description
-  company: your company (optional)
+  description: Configure the mongod service (includes populating mongod.conf) which is a MongoDB replicaset or standalone server.
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -15,7 +14,7 @@ galaxy_info:
   # - GPLv3
   # - Apache
   # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
+  license: GPLv3
 
   min_ansible_version: 1.2
 

--- a/roles/mongodb_mongos/meta/main.yml
+++ b/roles/mongodb_mongos/meta/main.yml
@@ -1,8 +1,7 @@
 ---
 galaxy_info:
-  author: your name
-  description: your description
-  company: your company (optional)
+  author: Rhys Campbell
+  description: Configure the mongos service (includes populating mongos.conf) which only runs in a sharded MongoDB cluster.
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -15,7 +14,7 @@ galaxy_info:
   # - GPLv3
   # - Apache
   # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
+  license: GPLv3
 
   min_ansible_version: 1.2
 

--- a/roles/mongodb_repository/meta/main.yml
+++ b/roles/mongodb_repository/meta/main.yml
@@ -1,8 +1,7 @@
 ---
 galaxy_info:
-  author: your name
-  description: your description
-  company: your company (optional)
+  author: Rhys Campbell
+  description: Configures a package repository for MongoDB on Debian and RedHat based platforms.
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -15,7 +14,7 @@ galaxy_info:
   # - GPLv3
   # - Apache
   # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
+  license: GPLv3
 
   min_ansible_version: 1.2
 

--- a/roles/mongodb_selinux/meta/main.yml
+++ b/roles/mongodb_selinux/meta/main.yml
@@ -1,8 +1,7 @@
 ---
 galaxy_info:
-  author: your name
-  description: your description
-  company: your company (optional)
+  author: Rhys Campbell
+  description: Configure SELinux for MongoDB.
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -15,7 +14,7 @@ galaxy_info:
   # - GPLv3
   # - Apache
   # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
+  license: GPLv3
 
   min_ansible_version: 1.2
 


### PR DESCRIPTION
##### SUMMARY
If you're new to setting up mongodb, figuring out which role to use can be confusing. The `mongodb_config` role is especially problematic, because standalone installations do not have a `config` server. The only "config" for standalone mongodb instances is the mongo.conf file, which is completely different. So, this adds a little map to help guide people in the right direction.

I tried to group the roles and plugins into some logical categories to help guide people to what they might want to use. Do my categories make sense?

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Readme