### PR TITLE
Make security.keyFile configurable

### DIFF
--- a/roles/mongodb_config/README.md
+++ b/roles/mongodb_config/README.md
@@ -15,6 +15,7 @@ Role Variables
 * `config_repl_set_name`: The replicaset name for the config servers. Default cfg.
 * `authorization`: Enable authorization. Default enabled.
 * `openssl_keyfile_content`: The kexfile content that MongoDB uses to authenticate within a replicaset. Generate with cmd: openssl rand -base64 756.
+* `openssl_keyfile_path`: Put the openssl_keyfile at this path. Default: /etc/keyfile
 * `mongod_package`: The name of the mongod installation package. Default mongodb-org-server.
 replicaset: When enabled add a replication section to the configuration. Default true.
 * `mongod_config_template`: If defined allows to override path to mongod config template with custom configuration. Default "mongod.conf.j2"

--- a/roles/mongodb_config/defaults/main.yml
+++ b/roles/mongodb_config/defaults/main.yml
@@ -5,6 +5,7 @@ bind_ip: 0.0.0.0
 # config_port is in vars to facilitate molecule tests
 config_repl_set_name: cfg
 authorization: enabled
+openssl_keyfile_path: /etc/keyfile
 openssl_keyfile_content: |
   Z2CeA9BMcoY5AUWoegjv/XWL2MA1SQcL4HvmRjYaTjSp/xosJy+LL2X3OQb1xVWC
   rO2e6Tu6A3R4muunitI6Vr0IKeU5UbTpR0N4hSU6HDrV9z2PIEWlkQqKh01ZRLEY

--- a/roles/mongodb_config/tasks/main.yml
+++ b/roles/mongodb_config/tasks/main.yml
@@ -46,7 +46,7 @@
   copy:
     content: |
       {{ openssl_keyfile_content }}
-    dest: /etc/keyfile
+    dest: "{{ openssl_keyfile_path }}"
     owner: "{{ mongodb_user }}"
     group: "{{ mongodb_group }}"
     mode: 0400

--- a/roles/mongodb_config/templates/configsrv.conf.j2
+++ b/roles/mongodb_config/templates/configsrv.conf.j2
@@ -32,7 +32,7 @@ net:
 {% if authorization == "enabled" %}
 security:
   authorization: {{ authorization }}
-  keyFile: /etc/keyfile
+  keyFile: {{ openssl_keyfile_path }}
 {% endif %}
 
 #operationProfiling:

--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -14,6 +14,7 @@ Role Variables
 * `repl_set_name`: The name of the replicaset the member will participate in. Default rs0.
 * `authorization`: Enable authorization. Default enabled.
 * `openssl_keyfile_content`: The keyfile content that MongoDB uses to authenticate within a replicaset. Generate with cmd: openssl rand -base64 756.
+* `openssl_keyfile_path`: Put the openssl_keyfile at this path. Default: /etc/keyfile
 * `mongodb_admin_user`: MongoDB admin username. Default admin.
 * `mongodb_admin_pwd`: MongoDB admin password. Default admin.
 * `mongod_package`: The mongod package to install. Default mongodb-org-server.

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -4,6 +4,7 @@ mongod_port: 27017
 bind_ip: 0.0.0.0
 repl_set_name: rs0
 authorization: "enabled"
+openssl_keyfile_path: /etc/keyfile
 openssl_keyfile_content: |
   Z2CeA9BMcoY5AUWoegjv/XWL2MA1SQcL4HvmRjYaTjSp/xosJy+LL2X3OQb1xVWC
   rO2e6Tu6A3R4muunitI6Vr0IKeU5UbTpR0N4hSU6HDrV9z2PIEWlkQqKh01ZRLEY

--- a/roles/mongodb_mongod/tasks/main.yml
+++ b/roles/mongodb_mongod/tasks/main.yml
@@ -46,7 +46,7 @@
   copy:
     content: |
       {{ openssl_keyfile_content }}
-    dest: /etc/keyfile
+    dest: "{{ openssl_keyfile_path }}"
     owner: "{{ mongodb_user }}"
     group: "{{ mongodb_group }}"
     mode: 0400

--- a/roles/mongodb_mongod/templates/mongod.conf.j2
+++ b/roles/mongodb_mongod/templates/mongod.conf.j2
@@ -16,7 +16,6 @@ storage:
     enabled: true
   engine: "wiredTiger"
 
-
 # how the process runs
 processManagement:
 {% if ansible_facts.os_family == "RedHat" %}  # Breaks Ubuntu / Debian
@@ -36,7 +35,7 @@ net:
 security:
   authorization: {{ authorization }}
 {% if replicaset or sharding %}
-  keyFile: /etc/keyfile
+  keyFile: {{ openssl_keyfile_path }}
 {% endif %}
 {% endif %}
 

--- a/roles/mongodb_mongos/README.md
+++ b/roles/mongodb_mongos/README.md
@@ -24,6 +24,7 @@ Role Variables
 * `config_repl_set_name`: The name of the config server replicaset. Default cfg.
 * `config_servers`: "config1:27019, config2:27019, config3:27019"
 * `openssl_keyfile_content`: The kexfile content that MongoDB uses to authenticate within a replicaset. Generate with cmd: openssl rand -base64 756.
+* `openssl_keyfile_path`: Put the openssl_keyfile at this path. Default: /etc/keyfile
 * `mongos_config_template`: If defined allows to override path to mongod config template with custom configuration. Default "mongos.conf.j2"
 * `skip_restart`: If set to `true` will skip restarting mongos service when config file or the keyfile content changes. Default `true`.
 

--- a/roles/mongodb_mongos/defaults/main.yml
+++ b/roles/mongodb_mongos/defaults/main.yml
@@ -7,6 +7,7 @@ mypy: python
 mongos_package: "mongodb-org-mongos"
 config_repl_set_name: cfg
 config_servers: "config1:27019, config2:27019, config3:27019"
+openssl_keyfile_path: /etc/keyfile
 openssl_keyfile_content: |
   Z2CeA9BMcoY5AUWoegjv/XWL2MA1SQcL4HvmRjYaTjSp/xosJy+LL2X3OQb1xVWC
   rO2e6Tu6A3R4muunitI6Vr0IKeU5UbTpR0N4hSU6HDrV9z2PIEWlkQqKh01ZRLEY

--- a/roles/mongodb_mongos/tasks/main.yml
+++ b/roles/mongodb_mongos/tasks/main.yml
@@ -30,7 +30,7 @@
   copy:
     content: |
       {{ openssl_keyfile_content }}
-    dest: /etc/keyfile
+    dest: "{{ openssl_keyfile_path }}"
     owner: "{{ mongodb_user }}"
     group: "{{ mongodb_group }}"
     mode: 0400

--- a/roles/mongodb_mongos/templates/mongos.conf.j2
+++ b/roles/mongodb_mongos/templates/mongos.conf.j2
@@ -11,4 +11,4 @@ sharding:
 processManagement:
   timeZoneInfo: /usr/share/zoneinfo
 security:
-  keyFile: /etc/keyfile
+  keyFile: {{ openssl_keyfile_path }}


### PR DESCRIPTION
In one cluster I help manage, we use /etc/mongod.key for the keyfile.
It would be nice to keep a consistent path when I start to use these roles.
So, this PR makes the path configurable.

To maintain backwards compatibility, the default path is still /etc/keyfile

- Make keyfile path configurable
- document openssl_keyfile_path
