### PR TITLE
Allow using net.bindIpAll instead of net.bindIp

### DIFF
--- a/roles/mongodb_config/README.md
+++ b/roles/mongodb_config/README.md
@@ -11,7 +11,8 @@ Role Variables
 * `mongodb_user`: The Linux OS user for MongoDB. Default mongod.
 * `mongodb_group`: The Linux OS user group for MongoDB. Default mongod.
 * `pid_file`: The pid file for mongos. Default /run/mongodb/mongos.pid.
-* `bind_ip`: The IP address mongos will bind to. Default 0.0.0.0.
+* `bind_ip`: The IP address mongod will bind to. Default 0.0.0.0.
+* `bind_ip_all`: Have mongod bind to all IP addresses instead of specifying `bind_ip`. Default false.
 * `config_repl_set_name`: The replicaset name for the config servers. Default cfg.
 * `authorization`: Enable authorization. Default enabled.
 * `openssl_keyfile_content`: The kexfile content that MongoDB uses to authenticate within a replicaset. Generate with cmd: openssl rand -base64 756.

--- a/roles/mongodb_config/defaults/main.yml
+++ b/roles/mongodb_config/defaults/main.yml
@@ -2,6 +2,7 @@
 # defaults file for mongodb_config
 pid_file: /var/run/mongodb/mongod.pid
 bind_ip: 0.0.0.0
+bind_ip_all: false
 # config_port is in vars to facilitate molecule tests
 config_repl_set_name: cfg
 authorization: enabled

--- a/roles/mongodb_config/templates/configsrv.conf.j2
+++ b/roles/mongodb_config/templates/configsrv.conf.j2
@@ -27,7 +27,11 @@ processManagement:
 # network interfaces
 net:
   port: {{ config_port }}
+{% if bind_ip_all %}
+  bindIpAll: true
+{% else %}
   bindIp: {{ bind_ip }}
+{% endif %}
 
 {% if authorization == "enabled" %}
 security:

--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -10,7 +10,8 @@ Role Variables
 * `mongod_service`: The name of the mongod service. Default mongod.
 * `mongodb_user`: The Linux OS user for MongoDB. Default mongod.
 * `mongodb_group`: The Linux OS user group for MongoDB. Default mongod.
-* `bind_ip`: The IP address mongos will bind to. Default 0.0.0.0.
+* `bind_ip`: The IP address mongod will bind to. Default 0.0.0.0.
+* `bind_ip_all`: Have mongod bind to all IP addresses instead of specifying `bind_ip`. Default false.
 * `repl_set_name`: The name of the replicaset the member will participate in. Default rs0.
 * `authorization`: Enable authorization. Default enabled.
 * `openssl_keyfile_content`: The keyfile content that MongoDB uses to authenticate within a replicaset. Generate with cmd: openssl rand -base64 756.

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -2,6 +2,7 @@
 # defaults file for mongodb_mongod
 mongod_port: 27017
 bind_ip: 0.0.0.0
+bind_ip_all: false
 repl_set_name: rs0
 authorization: "enabled"
 openssl_keyfile_content: |

--- a/roles/mongodb_mongod/templates/mongod.conf.j2
+++ b/roles/mongodb_mongod/templates/mongod.conf.j2
@@ -30,7 +30,11 @@ processManagement:
 # network interfaces
 net:
   port: {{ mongod_port }}
+{% if bind_ip_all %}
+  bindIpAll: true
+{% else %}
   bindIp: {{ bind_ip }}
+{% endif %}
 
 {% if authorization == "enabled" %}
 security:

--- a/roles/mongodb_mongos/README.md
+++ b/roles/mongodb_mongos/README.md
@@ -19,6 +19,7 @@ Role Variables
 * `mongodb_group`: The Linux OS user group for MongoDB. Default mongod.
 * `pid_file`: The pid file for mongos. Default /run/mongodb/mongos.pid.
 * `bind_ip`: The IP address mongos will bind to. Default 0.0.0.0.
+* `bind_ip_all`: Have mongos bind to all IP addresses instead of specifying `bind_ip`. Default false.
 * `mypy`: Python interpretor. Default python
 * `mongos_package`: The name of the mongos installation package. Default mongodb-org-mongos.
 * `config_repl_set_name`: The name of the config server replicaset. Default cfg.

--- a/roles/mongodb_mongos/defaults/main.yml
+++ b/roles/mongodb_mongos/defaults/main.yml
@@ -2,6 +2,7 @@
 # defaults file for mongodb_mongos
 pid_file: /run/mongodb/mongos.pid
 bind_ip: 0.0.0.0
+bind_ip_all: false
 # mongos_port in vars to facilitate molecule tests
 mypy: python
 mongos_package: "mongodb-org-mongos"

--- a/roles/mongodb_mongos/templates/mongos.conf.j2
+++ b/roles/mongodb_mongos/templates/mongos.conf.j2
@@ -4,7 +4,11 @@ systemLog:
   logAppend: true
   logRotate: reopen
 net:
+{% if bind_ip_all %}
+  bindIpAll: true
+{% else %}
   bindIp: {{ bind_ip }}
+{% endif %}
   port: {{ mongos_port }}
 sharding:
   configDB: "{{ config_repl_set_name }}/{{ config_servers }}"


### PR DESCRIPTION
I prefer using net.bindIpAll instead of setting net.bindIp.
This is available in mongo v3.6+.
See: https://docs.mongodb.com/manual/reference/configuration-options/#mongodb-setting-net.bindIpAll
