### PR TITLE
Allow overriding net.compression.compressors in mongo*.conf

### DIFF
--- a/roles/mongodb_config/README.md
+++ b/roles/mongodb_config/README.md
@@ -17,6 +17,7 @@ Role Variables
 * `openssl_keyfile_content`: The kexfile content that MongoDB uses to authenticate within a replicaset. Generate with cmd: openssl rand -base64 756.
 * `mongod_package`: The name of the mongod installation package. Default mongodb-org-server.
 replicaset: When enabled add a replication section to the configuration. Default true.
+* `net_compressors`: If this is set, this sets `net.compression.compressors` in mongod.conf.
 * `mongod_config_template`: If defined allows to override path to mongod config template with custom configuration. Default "mongod.conf.j2"
 * `skip_restart`: If set to `true` will skip restarting mongod service when config file or the keyfile content changes. Default `true`.
 

--- a/roles/mongodb_config/defaults/main.yml
+++ b/roles/mongodb_config/defaults/main.yml
@@ -24,5 +24,6 @@ openssl_keyfile_content: |
   mJfrCUVuP1nBEklk23lYkNi/ohe+aodNjdN+2DHp42sGZHYP
 mongod_package: "mongodb-org-server"
 replicaset: true
+net_compressors: null
 mongod_config_template: "configsrv.conf.j2"
 skip_restart: true

--- a/roles/mongodb_config/templates/configsrv.conf.j2
+++ b/roles/mongodb_config/templates/configsrv.conf.j2
@@ -28,6 +28,10 @@ processManagement:
 net:
   port: {{ config_port }}
   bindIp: {{ bind_ip }}
+{% if net_compressors %}
+  compression:
+    compressors: {{ net_compressors }}
+{% endif %}
 
 {% if authorization == "enabled" %}
 security:

--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -19,6 +19,7 @@ Role Variables
 * `mongod_package`: The mongod package to install. Default mongodb-org-server.
 * `replicaset`: When enabled add a replication section to the configuration. Default true.
 * `sharding`: If this replicaset member will form part of a sharded cluster. Default false.
+* `net_compressors`: If this is set, this sets `net.compression.compressors` in mongod.conf.
 * `mongod_config_template`: If defined allows to override path to mongod config template with custom configuration. Default "mongod.conf.j2"
 * `skip_restart`: If set to `true` will skip restarting mongod service when config file or the keyfile content changes. Default `true`.
 

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -26,5 +26,6 @@ mongodb_admin_pwd: admin
 mongod_package: "mongodb-org-server"
 replicaset: true
 sharding: false
+net_compressors: null
 mongod_config_template: "mongod.conf.j2"
 skip_restart: true

--- a/roles/mongodb_mongod/templates/mongod.conf.j2
+++ b/roles/mongodb_mongod/templates/mongod.conf.j2
@@ -31,6 +31,10 @@ processManagement:
 net:
   port: {{ mongod_port }}
   bindIp: {{ bind_ip }}
+{% if net_compressors %}
+  compression:
+    compressors: {{ net_compressors }}
+{% endif %}
 
 {% if authorization == "enabled" %}
 security:

--- a/roles/mongodb_mongos/README.md
+++ b/roles/mongodb_mongos/README.md
@@ -24,6 +24,7 @@ Role Variables
 * `config_repl_set_name`: The name of the config server replicaset. Default cfg.
 * `config_servers`: "config1:27019, config2:27019, config3:27019"
 * `openssl_keyfile_content`: The kexfile content that MongoDB uses to authenticate within a replicaset. Generate with cmd: openssl rand -base64 756.
+* `net_compressors`: If this is set, this sets `net.compression.compressors` in mongos.conf.
 * `mongos_config_template`: If defined allows to override path to mongod config template with custom configuration. Default "mongos.conf.j2"
 * `skip_restart`: If set to `true` will skip restarting mongos service when config file or the keyfile content changes. Default `true`.
 

--- a/roles/mongodb_mongos/defaults/main.yml
+++ b/roles/mongodb_mongos/defaults/main.yml
@@ -24,5 +24,6 @@ openssl_keyfile_content: |
   D3xVuE3WvrhldY5EOsaTt2ZXZx5REmJDIW1KcnvQKiVDJ2QzP5xdXYA0hh3TdTVE
   sb4UreMw/WyBpANiICMlJRBgSd0f0VGMlYzLX2BL14YpNnLhmoQqKzfBN6v2XAEG
   mJfrCUVuP1nBEklk23lYkNi/ohe+aodNjdN+2DHp42sGZHYP
+net_compressors: null
 mongos_config_template: "mongos.conf.j2"
 skip_restart: true

--- a/roles/mongodb_mongos/templates/mongos.conf.j2
+++ b/roles/mongodb_mongos/templates/mongos.conf.j2
@@ -6,6 +6,10 @@ systemLog:
 net:
   bindIp: {{ bind_ip }}
   port: {{ mongos_port }}
+{% if net_compressors %}
+  compression:
+    compressors: {{ net_compressors }}
+{% endif %}
 sharding:
   configDB: "{{ config_repl_set_name }}/{{ config_servers }}"
 processManagement:


### PR DESCRIPTION
In one of the clusters I help manage, we only allow snappy compression.
So, I need to be able to set `net.compression.compressors: snappy` in mongo config files.
This will let me do that using the `net_compressors` var.
