### PR TITLE
mongodb_shell: Adds support for the mongosh shell

### DIFF
--- a/plugins/modules/mongodb_shell.py
+++ b/plugins/modules/mongodb_shell.py
@@ -89,7 +89,7 @@ options:
       - Useful for escaping documents that are returned in Extended JSON format.
       - Automatically set to false when using mongo.
       - Automatically set to true when using mongosh.
-      - Set explicitly to override automiatic selection.
+      - Set explicitly to override automatic selection.
     type: bool
     default: null
   additional_args:
@@ -236,7 +236,10 @@ def transform_output(output, transform_type, split_char):
         try:
             output = json.loads(output)
         except json.decoder.JSONDecodeError:
-            output = re.sub(r'\:\s*\S+\s*\(\s*(\S+)\s*\)', r':\1', output)  # Strip Extended JSON Stuff
+            # Strip Extended JSON stuff like:
+            # "_id": ObjectId("58f56171ee9d4bd5e610d6b7"),
+            # "count": NumberLong(999),
+            output = re.sub(r'\:\s*\S+\s*\(\s*(\S+)\s*\)', r':\1', output)
             try:
                 output = json.loads(output)
             except json.decoder.JSONDecodeError as excep:

--- a/plugins/modules/mongodb_shell.py
+++ b/plugins/modules/mongodb_shell.py
@@ -14,11 +14,12 @@ author: Rhys Campbell (@rhysmeister)
 version_added: "1.1.0"
 short_description: Run commands via the MongoDB shell.
 requirements:
-  - mongo
+  - mongo or mongosh
 description:
     - Run commands via the MongoDB shell.
     - Commands provided with the eval parameter or included in a Javascript file.
     - Attempts to parse returned data into a format that Ansible can use.
+    - Module currently uses the mongo shell by default. This will change to mongosh in an upcoming version and support for mongo will be dropped
 
 extends_documentation_fragment:
   - community.mongodb.login_options
@@ -84,10 +85,13 @@ options:
     default: " "
   stringify:
     description:
-      - Wraps the command in eval in JSON.stringify(<js cmd>).
+      - Wraps the command in eval in JSON.stringify(<js cmd>) (mongo) or EJSON.stringify(<js cmd>) (mongosh).
       - Useful for escaping documents that are returned in Extended JSON format.
+      - Automatically set to false when using mongo.
+      - Automatically set to true when using mongosh.
+      - Set explicitly to override automiatic selection.
     type: bool
-    default: false
+    default: null
   additional_args:
     description:
       - Additional arguments to supply to the mongo command.
@@ -229,8 +233,15 @@ def transform_output(output, transform_type, split_char):
         else:
             tranform_type = "raw"
     if transform_type == "json":
-        output = re.sub(r'\:\s*\S+\s*\(\s*(\S+)\s*\)', r':\1',output)  # Strip Extended JSON Stuff
-        output = json.loads(output)
+        try:
+            output = json.loads(output)
+        except json.decoder.JSONDecodeError:
+            output = re.sub(r'\:\s*\S+\s*\(\s*(\S+)\s*\)', r':\1', output)  # Strip Extended JSON Stuff
+            try:
+                output = json.loads(output)
+            except json.decoder.JSONDecodeError:
+                output = re.sub("(\w+):", r'"\1":', output)  # Double quote field names when missing - mongosh
+                output = json.loads(output)
     elif transform_type == "split":
         output = output.strip().split(split_char)
     elif transform_type == "raw":
@@ -272,7 +283,7 @@ def main():
         debug=dict(type='bool', required=False, default=False),
         transform=dict(type='str', choices=["auto", "split", "json", "raw"], default="auto"),
         split_char=dict(type='str', default=" "),
-        stringify=dict(type='bool', default=False),
+        stringify=dict(type='bool', default=None),
         additional_args=dict(type='raw'),
         idempotent=dict(type='bool', default=False)
     )
@@ -282,6 +293,11 @@ def main():
         required_together=[['login_user', 'login_password']],
         mutually_exclusive=[["eval", "file"]]
     )
+
+    if module.params['mongo_cmd'] == "mongo" and module.params['stringify'] is None:
+        module.params['stringify'] = False
+    elif module.params['mongo_cmd'] == "mongosh" and module.params['stringify'] is None:
+        module.params['stringify'] = True
 
     args = [
         module.params['mongo_cmd'],
@@ -303,7 +319,10 @@ def main():
                   " inside the eval parameter because they are not valid JavaScript."
             module.fail_json(msg=msg)
         if module.params['stringify']:
-            module.params['eval'] = "JSON.stringify({0})".format(module.params['eval'])
+            if module.params['mongo_cmd'] != "mongosh":
+                module.params['eval'] = "JSON.stringify({0})".format(module.params['eval'])
+            else:
+                module.params['eval'] = "EJSON.stringify({0})".format(module.params['eval'])
 
     args = add_arg_to_cmd(args, "--host", module.params['login_host'])
     args = add_arg_to_cmd(args, "--port", module.params['login_port'])

--- a/plugins/modules/mongodb_shell.py
+++ b/plugins/modules/mongodb_shell.py
@@ -239,9 +239,8 @@ def transform_output(output, transform_type, split_char):
             output = re.sub(r'\:\s*\S+\s*\(\s*(\S+)\s*\)', r':\1', output)  # Strip Extended JSON Stuff
             try:
                 output = json.loads(output)
-            except json.decoder.JSONDecodeError:
-                output = re.sub("(\w+):", r'"\1":', output)  # Double quote field names when missing - mongosh
-                output = json.loads(output)
+            except json.decoder.JSONDecodeError as excep:
+                raise excep
     elif transform_type == "split":
         output = output.strip().split(split_char)
     elif transform_type == "raw":

--- a/tests/integration/targets/mongodb_shell/tasks/main.yml
+++ b/tests/integration/targets/mongodb_shell/tasks/main.yml
@@ -323,4 +323,327 @@
     that:
       - "run_file.changed == True"
 
+- name: Run tests for mongosh on MongoDB 5+
+  block:
+
+    - name: Ensure all success files are removed
+      file:
+        path: "{{ item }}"
+        state: "absent"
+      with_fileglob:
+        - "*.success"
+
+    - name: Ensure mongodb-org-shell package has been removed
+      package:
+        name: mongodb-org-shell
+        state: absent
+
+    - name: Ensure mongodb-mongosh package is installed
+      package:
+        name: mongodb-mongosh
+        state: present
+
+    - name: Run the listDatabases cmd
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        eval: "db.adminCommand('listDatabases')"
+        debug: yes
+      register: listDatabases
+
+    - assert:
+        that:
+          - "'databases' in listDatabases['transformed_output']"
+          - "'totalSize' in listDatabases['transformed_output']"
+
+    - name: List collections
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        eval: "db.adminCommand('listCollections')"
+        debug: yes
+        stringify: yes
+      register: listCollections
+
+    - assert:
+        that:
+          - "listCollections['transformed_output']['cursor']['firstBatch'] is iterable"
+
+    - name: Get log types
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        eval: "db.adminCommand({ 'getLog' : '*' })"
+        debug: yes
+      register: getLog
+
+    - assert:
+        that:
+          - "'global' in getLog['transformed_output']['names']"
+          - "'startupWarnings' in getLog['transformed_output']['names']"
+
+    - name: Get log startupWarnings
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        eval: "db.adminCommand({ 'getLog' : 'startupWarnings' })"
+        debug: yes
+      register: getLogstartupWarnings
+
+    - assert:
+        that:
+          - "'log' in getLogstartupWarnings['transformed_output']"
+          - "'initandlisten' in getLogstartupWarnings['transformed_output'] | string"
+          - "getLogstartupWarnings['transformed_output']['totalLinesWritten'] > 0"
+
+    - name: Show roles
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        eval: "db.getRoles({showBuiltinRoles: true})"
+        debug: yes
+      register: showRoles
+
+    - assert:
+        that:
+          - "showRoles['transformed_output'] is iterable"
+          - "'inheritedRoles' in showRoles['transformed_output'] | string"
+
+    - name: Run an unsupported shell helper cmd
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        eval: "show dbs"
+        debug: yes
+      register: bad_cmd
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - "bad_cmd.failed"
+          - "'the eval parameter because they are not valid JavaScript' in bad_cmd.msg"
+
+    - name: Copy a js file to the container - (with drop)
+      copy:
+        content: |
+          db = db.getSiblingDB('rhys');
+          db.dropDatabase()
+
+          let res = [
+            db.rhys.createIndex({ A: 1 }, { unique: true }),
+            db.rhys.createIndex({ B: 1 }),
+            db.rhys.createIndex({ C: 1 }),
+            db.rhys.insert({ A: 'hello world', B: 1, AA: 'test' }),
+            db.rhys.insert({ A: 'hello world 1', B: 1, BB: 'test' }),
+            db.rhys.insert({ A: 'hello world 2', B: 1, CC: 'test' }),
+            db.rhys.insert({ A: 'hello world 3', C: 1, DD: 'test' })
+           ];
+
+           printjson(res);
+
+           cursor = db.collection.find();
+           while ( cursor.hasNext() ) {
+             printjson( cursor.next() );
+           }
+        dest: /root/mongo.js
+
+    - name: Run a file containing MongoDB commands
+      community.mongodb.mongodb_shell:
+        mongo_cmd: "mongosh"
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        file: "/root/mongo.js"
+        quiet: no
+        debug: yes
+      register: run_file
+
+    - assert:
+        that:
+          - "'/root/mongo.js' in run_file.file"
+
+    - name: Check the rhys db has been created
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        eval: "db.adminCommand('listDatabases')"
+        debug: yes
+      register: rhysDB
+
+    - assert:
+        that:
+          - "'rhys' in rhysDB | string"
+
+    - name: Run a test with a dodgy mongo_cmd path
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "badmongo"
+        eval: "db.getRoles({showBuiltinRoles: true})"
+        debug: yes
+      register: bad_mongo
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - "'No such file or directory' in bad_mongo.msg"
+          - "bad_mongo.rc == 2"
+
+    - name: Test boolean flag (verbose)
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        eval: "db.adminCommand('listDatabases')"
+        debug: yes
+        additional_args:
+          verbose: True
+      register: rhysDB
+
+    - assert:
+        that:
+          - "'rhys' in rhysDB | string"
+          - "'--verbose' in rhysDB | string"
+
+    - name: Test string value flag (authenticationMechanism)
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        eval: "db.adminCommand('listDatabases')"
+        debug: yes
+        additional_args:
+          authenticationMechanism: "SCRAM-SHA-1"
+      register: rhysDB
+
+    - assert:
+        that:
+          - "'rhys' in rhysDB | string"
+          - "'--authenticationMechanism SCRAM-SHA-1' in rhysDB | string"
+
+    - name: Test string and boolean value flag together
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        eval: "db.adminCommand('listDatabases')"
+        debug: yes
+        additional_args:
+          verbose: True
+          authenticationMechanism: "SCRAM-SHA-1"
+      register: rhysDB
+
+    - assert:
+        that:
+          - "'rhys' in rhysDB | string"
+          - "'--verbose' in rhysDB | string"
+          - "'--authenticationMechanism SCRAM-SHA-1' in rhysDB | string"
+
+    - name: Test command with idempotent on 1
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        eval: "db.adminCommand('listDatabases')"
+        debug: yes
+        additional_args:
+          authenticationMechanism: "SCRAM-SHA-1"
+        idempotent: yes
+      register: rhysDB
+
+    - assert:
+        that:
+          - "'rhys' in rhysDB | string"
+          - "'--authenticationMechanism SCRAM-SHA-1' in rhysDB | string"
+          - "rhysDB.changed"
+
+    - name: Test command with idempotent on 2
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        eval: "db.adminCommand('listDatabases')"
+        debug: yes
+        additional_args:
+          authenticationMechanism: "SCRAM-SHA-1"
+        idempotent: yes
+      register: rhysDB
+
+    - assert:
+        that:
+          - "rhysDB.changed == False"
+          - "'.success was found meaning this command has already successfully executed' in rhysDB.msg"
+
+    - name: Test file with idempotent on 1
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        file: "/root/mongo.js"
+        quiet: no
+        debug: yes
+        idempotent: yes
+      register: run_file
+
+    - assert:
+        that:
+          - "run_file.changed"
+          - "'/root/mongo.js' in run_file.file"
+
+    - name: Test file with idempotent on 2
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        file: "/root/mongo.js"
+        quiet: no
+        debug: yes
+        idempotent: yes
+      register: run_file
+
+    - assert:
+        that:
+          - "run_file.changed == False"
+          - "'.success was found meaning this command has already successfully executed' in run_file.msg"
+
+    - name: Test file with idempotent off - should run
+      community.mongodb.mongodb_shell:
+        login_user: '{{ mongodb_admin_user }}'
+        login_password: '{{ mongodb_admin_password }}'
+        login_port: 3001
+        mongo_cmd: "mongosh"
+        file: "/root/mongo.js"
+        quiet: no
+        debug: yes
+        idempotent: no
+      register: run_file
+
+    - assert:
+        that:
+          - "run_file.changed == True"
+
+  when: mongodb_version[0] | int >= 5
+
 - include_tasks: mongod_teardown.yml


### PR DESCRIPTION
##### SUMMARY

Adds support for the mongosh shell. There were some annoying differences in output between the mongo and mongosh shells. By default I wrap all mongosh commands in the EJSON.stringify helper. By default the mongo shell is still used. I think it's probably simpler to remove support for the mongo shell in the not too distant future.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mongodb_shell