### PR TITLE
Bug Fix: Add pymongo==3.12.2

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           timeout_minutes: 3
           max_attempts: 3
-          command: pip install mtools pymongo psutil coverage==4.5.4 pytest-xdist
+          command: pip install mtools pymongo==3.12.2 psutil coverage==4.5.4 pytest-xdist
 
       - name: Start a replicaset with mtools (3 nodes, starting from port 27017)
         run: mlaunch --replicaset --auth

--- a/.github/workflows/mongodb-cache.yml
+++ b/.github/workflows/mongodb-cache.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           timeout_minutes: 3
           max_attempts: 3
-          command: pip install pymongo
+          command: pip install pymongo==3.12.2
 
       - name: Run ansible to generate the mongodb cache
         run: ansible localhost -m setup

--- a/.github/workflows/x509.yml
+++ b/.github/workflows/x509.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           timeout_minutes: 3
           max_attempts: 3
-          command: pip install pymongo
+          command: pip install pymongo==3.12.2
 
       - name: Run mongodb_user module with membership auth
         run: ansible localhost -m community.mongodb.mongodb_user -a "login_host=localhost login_port=27017 login_database='$external' database='admin' password='secret' ssl=true ssl_ca_certs=ca.crt ssl_certfile=tls.key auth_mechanism=MONGODB-X509 name="test" state=present connection_options='tlsAllowInvalidHostnames=true'"

--- a/requirements-2.7.txt
+++ b/requirements-2.7.txt
@@ -7,3 +7,4 @@ pytest==4.6.9
 python-vagrant==0.5.15
 # sh 1.13.1 causes molecule yamllint to fail.
 sh<1.13
+pymongo==3.12.2

--- a/requirements-3.5.txt
+++ b/requirements-3.5.txt
@@ -6,3 +6,4 @@ molecule>=2.22,<3.0
 pytest==5.3.4
 python-vagrant==0.5.15
 sh==1.13.1
+pymongo==3.12.2

--- a/requirements-3.6.txt
+++ b/requirements-3.6.txt
@@ -6,3 +6,4 @@ molecule>=2.22,<3.0
 pytest==5.3.4
 python-vagrant==0.5.15
 sh==1.13.1
+pymongo==3.12.2

--- a/requirements-3.8.txt
+++ b/requirements-3.8.txt
@@ -6,3 +6,4 @@ molecule>=2.22,<3.0
 pytest==5.3.4
 python-vagrant==0.5.15
 sh==1.13.1
+pymongo==3.12.2

--- a/roles/mongodb_auth/molecule/default/playbook.yml
+++ b/roles/mongodb_auth/molecule/default/playbook.yml
@@ -54,7 +54,7 @@
 
     - name: Install pymongo
       pip:
-        name: pymongo
+        name: pymongo==3.12.2
 
     - name: Enable mongo auth
       include_role:

--- a/roles/mongodb_config/molecule/custom_db_path/playbook.yml
+++ b/roles/mongodb_config/molecule/custom_db_path/playbook.yml
@@ -17,7 +17,7 @@
 
     - name: Install pymongo
       pip:
-        name: pymongo
+        name: pymongo==3.12.2
       when: ansible_hostname == "ubuntu_16"
 
     - name: Install MongoDB Shell

--- a/roles/mongodb_config/molecule/default/playbook.yml
+++ b/roles/mongodb_config/molecule/default/playbook.yml
@@ -15,7 +15,7 @@
 
     - name: Install pymongo
       pip:
-        name: pymongo
+        name: pymongo==3.12.2
       when: ansible_hostname == "ubuntu_16"
 
     - name: Install MongoDB Shell

--- a/roles/mongodb_mongod/molecule/custom_db_path/playbook.yml
+++ b/roles/mongodb_mongod/molecule/custom_db_path/playbook.yml
@@ -17,7 +17,7 @@
 
     - name: Install pymongo
       pip:
-        name: pymongo
+        name: pymongo==3.12.2
       when: ansible_hostname == "ubuntu_16"
 
     - name: Install MongoDB Shell

--- a/roles/mongodb_mongod/molecule/default/playbook.yml
+++ b/roles/mongodb_mongod/molecule/default/playbook.yml
@@ -15,7 +15,7 @@
 
     - name: Install pymongo
       pip:
-        name: pymongo
+        name: pymongo==3.12.2
       when: ansible_hostname == "ubuntu_16"
 
     - name: Install MongoDB Shell

--- a/roles/mongodb_mongos/molecule/default/playbook.yml
+++ b/roles/mongodb_mongos/molecule/default/playbook.yml
@@ -28,7 +28,7 @@
 
     - name: Install pymongo
       pip:
-        name: pymongo
+        name: pymongo==3.12.2
       when: ansible_hostname == "config1"
 
     - name: Install MongoDB Shell

--- a/tests/integration/targets/setup_mongodb/defaults/main.yml
+++ b/tests/integration/targets/setup_mongodb/defaults/main.yml
@@ -18,4 +18,4 @@ yum:
   fedoraurl: https://repo.mongodb.org/yum/amazon/2013.03/mongodb-org/{{mongodb_version}}/x86_64/
 pip_packages:
 - psutil
-- pymongo
+- pymongo==3.12.2


### PR DESCRIPTION
##### SUMMARY

Getting connection pool errors with pymongo 4.0. Using the previous version for now.

pymongo.errors.AutoReconnect: localhost:27027: connection pool paused

##### ISSUE TYPE
- Bugfix Pull Request