### PR TITLE
Try to execute command before auth

### DIFF
--- a/plugins/modules/mongodb_stepdown.py
+++ b/plugins/modules/mongodb_stepdown.py
@@ -252,14 +252,25 @@ def main():
     except Exception as e:
         module.fail_json(msg='Unable to connect to database: %s' % to_native(e))
 
-    mongo_auth(module, client)
-
+    executed = False
     try:
         status, msg, return_doc = member_stepdown(client, module)
         iterations = return_doc['iterations']
         changed = return_doc['changed']
+        executed = True
     except Exception as e:
-        module.fail_json(msg='Unable to query replica_set info: %s' % str(e))
+        pass
+
+    if not executed:
+        mongo_auth(module, client)
+
+        try:
+            status, msg, return_doc = member_stepdown(client, module)
+            iterations = return_doc['iterations']
+            changed = return_doc['changed']
+            executed = True
+        except Exception as e:
+            module.fail_json(msg='Unable to query replica_set info: %s' % str(e))
 
     if status is False:
         module.fail_json(msg=msg, iterations=iterations, changed=changed)

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -409,19 +409,12 @@ def main():
         module.fail_json(msg=missing_required_lib('pymongo'),
                          exception=PYMONGO_IMP_ERR)
 
-    
     login_password = module.params['login_password']
     login_host = module.params['login_host']
     login_port = module.params['login_port']
-    login_database = module.params['login_database']
-
     replica_set = module.params['replica_set']
-    
-    
-    
     ssl = module.params['ssl']
     state = module.params['state']
-    
 
     connection_params = {
         "host": login_host,
@@ -463,7 +456,6 @@ def main():
 
     user = module.params['name']
     module.exit_json(changed=True, user=user)
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The idea is first to try to execute command and if it doesn't work run the authentification.    
Fix #427
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- mongodb_status
- mongodb_stepdown
- mongodb_user

But may be other module needs to be updated

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

With this modification it is possible to remove `create_for_localhost_exception` (not work with shared nodes (because file is not present on all nodes)). 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```YAML
- name: Create admin user
  community.mongodb.mongodb_user:
    login_host: localhost
    login_port: "{{ mongo_port }}"
    login_user: "{{ mongo_admin_user }}"
    login_password: "{{ mongo_admin_pwd }}"
    login_database: "{{ mongo_admin_db }}"
    database: "{{ mongo_admin_db }}"
    name: "{{ mongo_admin_user }}"
    password: "{{ mongo_admin_pwd }}"
    roles: root
    state: present
```
If the user is already created, credentials will be used and it will not failed.
