### PR TITLE
#448 - mongod not restarting if there's a custom bind_ip set

### DIFF
--- a/roles/mongodb_config/handlers/main.yml
+++ b/roles/mongodb_config/handlers/main.yml
@@ -9,6 +9,6 @@
 - name: Wait for port to become active
   listen: Restart mongod service
   wait_for:
-    host: "{{ bind_ip }} "
+    host: "{{ bind_ip }}"
     port: "{{ config_port }}"
   when: not skip_restart

--- a/roles/mongodb_config/handlers/main.yml
+++ b/roles/mongodb_config/handlers/main.yml
@@ -9,5 +9,6 @@
 - name: Wait for port to become active
   listen: Restart mongod service
   wait_for:
+    host: "{{ bind_ip }} "
     port: "{{ config_port }}"
   when: not skip_restart

--- a/roles/mongodb_mongod/handlers/main.yml
+++ b/roles/mongodb_mongod/handlers/main.yml
@@ -9,5 +9,6 @@
 - name: Wait for port to become active
   listen: Restart mongod service
   wait_for:
+    host: "{{ bind_ip }} "
     port: "{{ mongod_port }}"
   when: not skip_restart

--- a/roles/mongodb_mongod/handlers/main.yml
+++ b/roles/mongodb_mongod/handlers/main.yml
@@ -9,6 +9,6 @@
 - name: Wait for port to become active
   listen: Restart mongod service
   wait_for:
-    host: "{{ bind_ip }} "
+    host: "{{ bind_ip }}"
     port: "{{ mongod_port }}"
   when: not skip_restart

--- a/roles/mongodb_mongos/handlers/main.yml
+++ b/roles/mongodb_mongos/handlers/main.yml
@@ -9,5 +9,6 @@
 - name: Wait for port to become active
   listen: Restart mongos service
   wait_for:
+    host: "{{ bind_ip }} "
     port: "{{ mongos_port }}"
   when: not skip_restart

--- a/roles/mongodb_mongos/handlers/main.yml
+++ b/roles/mongodb_mongos/handlers/main.yml
@@ -9,6 +9,6 @@
 - name: Wait for port to become active
   listen: Restart mongos service
   wait_for:
-    host: "{{ bind_ip }} "
+    host: "{{ bind_ip }}"
     port: "{{ mongos_port }}"
   when: not skip_restart


### PR DESCRIPTION
##### SUMMARY
This pull request fixes #448 - with the additional variable `host:` the playbooks are able to check the services after a restart,
if there's a custom `bind_ip` set, without failing. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- mongodb_config
- mongodb_mongod
- mongodb_mongos
