### PR TITLE
Sanity tests: copy ignore-2.13.txt to ignore-2.14.txt

### DIFF
--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,0 +1,2 @@
+tests/ansible-operator/config/manager/manager.yaml yamllint:unparsable-with-libyaml
+tests/ansible-operator/roles/create-certificates/templates/certificate.yaml yamllint:unparsable-with-libyaml


### PR DESCRIPTION
##### SUMMARY
Sanity tests: copy ignore-2.13.txt to ignore-2.14.txt

Relates to https://github.com/ansible-collections/news-for-maintainers/issues/13