### PR TITLE
Allowing for different log path

### DIFF
--- a/roles/mongodb_config/defaults/main.yml
+++ b/roles/mongodb_config/defaults/main.yml
@@ -3,6 +3,7 @@
 pid_file: /var/run/mongodb/mongod.pid
 bind_ip: 0.0.0.0
 bind_ip_all: false
+log_path: /var/log/mongodb/mongod.log
 # config_port is in vars to facilitate molecule tests
 config_repl_set_name: cfg
 authorization: enabled

--- a/roles/mongodb_config/templates/configsrv.conf.j2
+++ b/roles/mongodb_config/templates/configsrv.conf.j2
@@ -7,7 +7,7 @@
 systemLog:
   destination: file
   logAppend: true
-  path: /var/log/mongodb/mongod.log
+  path: {{ log_path }}
 
 # Where and how to store data.
 storage:


### PR DESCRIPTION
##### SUMMARY
It could be a nice addition to allow for different logging path. This is what this PR does, by allowing to overring a new variable (`log_path`) which is still the same as for now so it does not add any breaking change.

##### ISSUE TYPE
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
mongodb_config
