### PR TITLE
Add auth when creating RS

### DIFF
--- a/plugins/modules/mongodb_replicaset.py
+++ b/plugins/modules/mongodb_replicaset.py
@@ -594,6 +594,7 @@ def main():
 
         if module.check_mode is False:
             try:
+                client = mongo_auth(module, client, directConnection=True)
                 replicaset_add(module, client, replica_set, members,
                                arbiter_at_index, protocol_version,
                                chaining_allowed, heartbeat_timeout_secs,


### PR DESCRIPTION
##### SUMMARY
When creating RS, mongodb_replicaset module does not use authentication, so each attempt results to error message `Unable to create replica_set: Some problem command replSetInitiate requires authentication`.
So if no RS exists, it's necessary to authenticate before adding new replicas.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.mongodb.mongodb_replicaset

##### ADDITIONAL INFORMATION
Mongo server 5.0.8
Pymongo 4.1.1
community.mongodb 1.4.0

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
BEFORE: "msg": "Unable to create replica_set: Some problem command replSetInitiate requires authentication, full error: {'ok': 0.0, 'errmsg': 'command replSetInitiate requires authentication', 'code': 13, 'codeName': 'Unauthorized'}
AFTER: {"changed": true, "replica_set": "replicaSetName"...}
```
