### PR TITLE
Limit community.general collection version

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -195,7 +195,7 @@ jobs:
         with:
           timeout_minutes: 3
           max_attempts: 3
-          command: ansible-galaxy collection install community.general -p ansible_collections/
+          command: ansible-galaxy collection install 'community.general:<5.0.0' -p ansible_collections/
 
       - name: Install community.crypto
         uses: nick-invision/retry@v2
@@ -273,7 +273,7 @@ jobs:
         with:
           timeout_minutes: 3
           max_attempts: 3
-          command: ansible-galaxy collection install community.general -p ansible_collections/
+          command: ansible-galaxy collection install 'community.general:<5.0.0' -p ansible_collections/
 
       - name: Install community.crypto
         uses: nick-invision/retry@v2

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,7 +19,7 @@ tags:
   - nosql
 dependencies:
   # pam_limits module in mongodb_linux role; role tests use pids module
-  community.general: '>=1.0.0'
+  community.general: '>=1.0.0,<5.0.0'
   # sysctl module in mongodb_linux role
   ansible.posix: '>=1.0.0'
   # role tests use openssl_ modules


### PR DESCRIPTION
##### SUMMARY
Limit version of community.general to less than 5 due to this https://github.com/ansible-collections/community.general/issues/4706

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.mongodb