### PR TITLE
Address issues highlighted in #477

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -195,7 +195,7 @@ jobs:
         with:
           timeout_minutes: 3
           max_attempts: 3
-          command: ansible-galaxy collection install 'community.general:<5.0.0' -p ansible_collections/
+          command: ansible-galaxy collection install 'community.general' -p ansible_collections/
 
       - name: Install community.crypto
         uses: nick-invision/retry@v2
@@ -273,7 +273,7 @@ jobs:
         with:
           timeout_minutes: 3
           max_attempts: 3
-          command: ansible-galaxy collection install 'community.general:<5.0.0' -p ansible_collections/
+          command: ansible-galaxy collection install 'community.general' -p ansible_collections/
 
       - name: Install community.crypto
         uses: nick-invision/retry@v2

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,7 +19,7 @@ tags:
   - nosql
 dependencies:
   # pam_limits module in mongodb_linux role; role tests use pids module
-  community.general: '>=1.0.0,<5.0.0'
+  community.general: '>=1.0.0'
   # sysctl module in mongodb_linux role
   ansible.posix: '>=1.0.0'
   # role tests use openssl_ modules

--- a/roles/mongodb_linux/tasks/main.yml
+++ b/roles/mongodb_linux/tasks/main.yml
@@ -150,6 +150,7 @@
 # Tasks based on: https://docs.mongodb.com/manual/reference/ulimit/
 
 - name: Set pam limits (nproc and nofile)
+  # TODO: replace with `community.general.pam_limits` once support for Ansible 2.9 is dropped
   community.general.system.pam_limits:
     domain: "{{ item[0] }}"
     limit_type: "{{ item[1] }}"

--- a/roles/mongodb_linux/tasks/main.yml
+++ b/roles/mongodb_linux/tasks/main.yml
@@ -150,7 +150,7 @@
 # Tasks based on: https://docs.mongodb.com/manual/reference/ulimit/
 
 - name: Set pam limits (nproc and nofile)
-  community.general.pam_limits:
+  community.general.system.pam_limits:
     domain: "{{ item[0] }}"
     limit_type: "{{ item[1] }}"
     limit_item: "{{ item[2] }}"
@@ -165,7 +165,7 @@
     - "setup"
 
 - name: Set pam limits (memlock)
-  community.general.pam_limits:
+  community.general.system.pam_limits:
     domain: "{{ item[0] }}"
     limit_type: "{{ item[1] }}"
     limit_item: "{{ item[2] }}"


### PR DESCRIPTION
##### SUMMARY

- Use extended FQCN for pam_limits (community.general.system.pam_limits instead of community.general.pam_limits)
- Remove upper bound restriction for community.general collection

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- mongodb_linux role
- galaxy.yml
- CI Workflows