### PR TITLE
Remove module defaults on task level

### DIFF
--- a/roles/mongodb_auth/tasks/main.yml
+++ b/roles/mongodb_auth/tasks/main.yml
@@ -50,8 +50,6 @@
     login_host: localhost
     login_port: "{{ mongod_port | string }}"  # silence implicit int->str conversion warning
     create_for_localhost_exception: /root/mongodb_admin.success
-  module_defaults:
-    community.mongodb.mongodb_user: {}
   tags:
     - "mongodb"
     - "setup"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The admin user is not being inserted at the task level as they have the `module_defaults` set. The module_defaults should be specified at the playbook level only.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I had this playbook specifying the module defaults for the role:
```
- name: Create Mongo User
  hosts: mongodb[0]
  module_defaults:
    community.mongodb.mongodb_user:
      ssl: True
      ssl_ca_certs: "{{ mongodb_certificate_ca_file }}"
      ssl_cert_reqs: "CERT_NONE"
      connection_options: 
      - "tlsAllowInvalidCertificates=true"
  roles:
    - role: community.mongodb.mongodb_auth
      vars:
        mongod_host: "127.0.0.1"
        mongodb_users:
        - user: "{{ mongodb_graylog_admin_user }}"
          pwd: "{{ mongodb_graylog_admin_password }}"
          db: graylog
          roles:
          - dbOwner
```
But the task named `Add mongo admin user with localhost exception` was not being executed correctly because it was overriding the module_default values to {} from the ones provided by the upper playbook


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
