### PR TITLE
ansibleoperator: Update MongoDB Repo to 6.0

### DIFF
--- a/.github/workflows/x509.yml
+++ b/.github/workflows/x509.yml
@@ -82,10 +82,10 @@ jobs:
           kubectl cp ansible-operator-system/${managerpod}:/tmp/mongodb-sample.default/ca.crt ca.crt -c manager
           kubectl cp ansible-operator-system/${managerpod}:/tmp/mongodb-sample.default/tls.key tls.key -c manager
 
-      - name: Run mongo shell command to test x509 membership connectivity
+      - name: Run mongosh shell command to test x509 membership connectivity
         run: |
           kubectl -n ansible-operator-system exec -ti deployment.apps/ansible-operator-controller-manager -c manager -- \
-              /usr/bin/mongo mongodb://mongodb-sample.default.svc.cluster.local \
+              /usr/bin/mongosh mongodb://mongodb-sample.default.svc.cluster.local \
                     --tls \
                     --tlsCAFile /tmp/mongodb-sample.default/ca.crt \
                     --tlsCertificateKeyFile /tmp/mongodb-sample.default/tls.key \
@@ -93,9 +93,9 @@ jobs:
                     --authenticationDatabase '$external' \
                     --eval "db.adminCommand('listDatabases')"
 
-      - name: Run mongo shell command to test x509 membership connectivity from localhost
+      - name: Run mongosh shell command to test x509 membership connectivity from localhost
         run: |
-          /usr/bin/mongo mongodb://127.0.0.1 \
+          /usr/bin/mongosh mongodb://127.0.0.1 \
                     --tls \
                     --tlsCAFile ca.crt \
                     --tlsCertificateKeyFile tls.key \

--- a/tests/ansible-operator/Dockerfile
+++ b/tests/ansible-operator/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/operator-framework/ansible-operator:v1.0.0
 
 USER 0
-COPY tests/ansible-operator/mongodb-org-4.2.repo /etc/yum.repos.d/mongodb-org-4.2.repo
+COPY tests/ansible-operator/mongodb-org-6.0.repo /etc/yum.repos.d/mongodb-org-6.0.repo
 RUN yum -y update \
     && yum install -y python36-devel python3-pip python3-setuptools mongodb-org-shell
 

--- a/tests/ansible-operator/Dockerfile
+++ b/tests/ansible-operator/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/operator-framework/ansible-operator:v1.0.0
 USER 0
 COPY tests/ansible-operator/mongodb-org-6.0.repo /etc/yum.repos.d/mongodb-org-6.0.repo
 RUN yum -y update \
-    && yum install -y python36-devel python3-pip python3-setuptools mongodb-org-shell
+    && yum install -y python36-devel python3-pip python3-setuptools mongodb-mongosh
 
 RUN rm /etc/yum.repos.d/mongodb-org-4.2.repo
 

--- a/tests/ansible-operator/Dockerfile
+++ b/tests/ansible-operator/Dockerfile
@@ -5,7 +5,7 @@ COPY tests/ansible-operator/mongodb-org-6.0.repo /etc/yum.repos.d/mongodb-org-6.
 RUN yum -y update \
     && yum install -y python36-devel python3-pip python3-setuptools mongodb-mongosh
 
-RUN rm /etc/yum.repos.d/mongodb-org-4.2.repo
+RUN rm /etc/yum.repos.d/mongodb-org-6.0.repo
 
 RUN pip3 install pymongo
 

--- a/tests/ansible-operator/mongodb-org-4.2.repo
+++ b/tests/ansible-operator/mongodb-org-4.2.repo
@@ -1,6 +1,0 @@
-[mongodb-org-4.2]
-name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/4.2/x86_64/
-gpgcheck=1
-enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-4.2.asc

--- a/tests/ansible-operator/mongodb-org-6.0.repo
+++ b/tests/ansible-operator/mongodb-org-6.0.repo
@@ -1,0 +1,6 @@
+[mongodb-org-6.0]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/6.0/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-6.0.asc

--- a/tests/ansible-operator/playbooks/templates/mongo.yaml
+++ b/tests/ansible-operator/playbooks/templates/mongo.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: mongo
-          image: mongo:4.2.9
+          image: mongo:6.0.2
           command:
             - "/bin/sh"
             - "-c"


### PR DESCRIPTION
##### SUMMARY
The ansibleoperator for the X509 tests were still using MongoDB 4.2. This updates to 6.0.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tests/ansibleoperator