### PR TITLE
Transport `state` from user definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv/*
 *.tar.gz
 tests/output/*
 **/__pycache__/*
+.idea/*

--- a/roles/mongodb_auth/README.md
+++ b/roles/mongodb_auth/README.md
@@ -22,7 +22,7 @@ Role Variables
 * `mongodb_admin_user`: MongoDB admin username. Default admin.
 * `mongodb_admin_pwd`: MongoDB admin password. Defaults to value of mongodb_admin_default_pwd.
 * `mongodb_admin_default_pwd`: MongoDB admin password (for parent roles to override without overriding user's password). Default admin.
-* `mongodb_users`: List of additional users to add. Each user dict should include fields: db, user, pwd, roles
+* `mongodb_users`: List of additional users to add. Each user dict should include fields: db, user, pwd, state (default: "present"), roles (default: "readWrite").
 * `mongodb_force_update_password`: Whether or not to force a password update for any users in mongodb_users. Setting this to yes will result in 'changed' on every run, even if the password is the same. Setting this to no only adds a password when creating the user.
 
 IMPORTANT NOTE: It is expected that mongodb_admin_user & mongodb_admin_pwd values be overridden in your own file protected by Ansible Vault. Any production environments should protect these values. For more information see [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)

--- a/roles/mongodb_auth/defaults/main.yml
+++ b/roles/mongodb_auth/defaults/main.yml
@@ -11,7 +11,7 @@ mongodb_admin_user: admin
 mongodb_admin_pwd: "{{ mongodb_default_admin_pwd }}"
 # The default is separate so other roles can provide a default without overriding a user provided password.
 mongodb_default_admin_pwd: admin
-# allow for alternate admin roles (eg userAdminAnyDatabase)
+# allow for alternate admin roles (e.g. userAdminAnyDatabase)
 mongodb_admin_roles: "root"
 
 # Additional users to add.
@@ -19,9 +19,10 @@ mongodb_users: []
 #  - db: somedatabase
 #    user: someuser
 #    pwd: "S0meP@ss"
-#    roles: readWrite
+#    state: present    # can be omitted
+#    roles: readWrite  # if omitted "readWrite" will be used
 
-# whether or not to force a password update for any users in mongodb_users
+# whether to force a password update for any users in mongodb_users
 # Setting this to yes will result in 'changed' on every run, even if the password is the same.
 # See the comment in tasks/main.yml for more details.
 mongodb_force_update_password: no

--- a/roles/mongodb_auth/tasks/mongodb_auth_user.yml
+++ b/roles/mongodb_auth/tasks/mongodb_auth_user.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Add mongo auth user - {{ _mongodb_user.user }} on {{ _mongodb_user.db }}"
   community.mongodb.mongodb_user:
-    state: present
+    state: "{{ _mongodb_user.state|default('present') }}"
 
     # NOTE: on_create is idempotent, always is not.
     # With `update_password: on_create`, mongodb_user checks to see if the user


### PR DESCRIPTION
default to `present` to keep the change backward compatible

After this change one can delete users.

##### SUMMARY
Be able to delete users.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
role - mongo_auth
