### PR TITLE
mongodb_linux: Remove extended FQCN for pam_limits

### DIFF
--- a/roles/mongodb_linux/tasks/main.yml
+++ b/roles/mongodb_linux/tasks/main.yml
@@ -150,8 +150,7 @@
 # Tasks based on: https://docs.mongodb.com/manual/reference/ulimit/
 
 - name: Set pam limits (nproc and nofile)
-  # TODO: replace with `community.general.pam_limits` once support for Ansible 2.9 is dropped
-  community.general.system.pam_limits:
+  community.general.pam_limits:
     domain: "{{ item[0] }}"
     limit_type: "{{ item[1] }}"
     limit_item: "{{ item[2] }}"
@@ -166,7 +165,7 @@
     - "setup"
 
 - name: Set pam limits (memlock)
-  community.general.system.pam_limits:
+  community.general.pam_limits:
     domain: "{{ item[0] }}"
     limit_type: "{{ item[1] }}"
     limit_item: "{{ item[2] }}"


### PR DESCRIPTION
##### SUMMARY

The newly release 6.0 version of the general collection introduced a breaking change...

https://github.com/ansible-collections/community.mongodb/actions/runs/3416840761/jobs/5699987990

> ERROR! couldn't resolve module/action 'community.general.system.pam_limits'. This often indicates a misspelling, missing collection, or incorrect module path.
> The error appears to be in '/home/runner/work/community.mongodb/community.mongodb/ansible_collections/community/mongodb/roles/mongodb_linux/tasks/main.yml': line 152, column 3, but may be elsewhere in the file depending on the exact syntax problem.
> 
> The offending line appears to be:
> - name: Set pam limits (nproc and nofile)
> ^ here
> ERROR:

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mongodb_linux