### PR TITLE
Replace set-output by GITHUB_OUTPUT new syntax

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -132,7 +132,7 @@ jobs:
         id: json-list
         run: |
           output=$(cat int_test_modules.json)
-          echo "::set-output name=modules-to-test::$output"
+          echo "modules-to-test=$output" >> $GITHUB_OUTPUT
           echo "$output"
 
   integration:

--- a/.github/workflows/mongodb-cache.yml
+++ b/.github/workflows/mongodb-cache.yml
@@ -81,7 +81,7 @@ jobs:
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
           output="${output//$'\r'/'%0D'}"
-          echo "::set-output name=nopymongo::$output"
+          echo "nopymongo=$output" >> $GITHUB_OUTPUT
 
       - name: Test cache handling of missing pymongo
         uses: nick-invision/assert-action@v1
@@ -108,7 +108,7 @@ jobs:
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
           output="${output//$'\r'/'%0D'}"
-          echo "::set-output name=mongo::$output"
+          echo "mongo=$output" >> $GITHUB_OUTPUT
 
       - name: Test that we have something that looks like a cache record
         uses: nick-invision/assert-action@v1
@@ -125,7 +125,7 @@ jobs:
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
           output="${output//$'\r'/'%0D'}"
-          echo "::set-output name=mongo::$output"
+          echo "mongo=$output" >> $GITHUB_OUTPUT
 
       - name: Test that we don't have an index called ttl
         uses: nick-invision/assert-action@v1
@@ -152,7 +152,7 @@ jobs:
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
           output="${output//$'\r'/'%0D'}"
-          echo "::set-output name=mongo::$output"
+          echo "mongo=$output" >> $GITHUB_OUTPUT
 
       - name: Test that we have something that looks like a cache record
         uses: nick-invision/assert-action@v1
@@ -169,7 +169,7 @@ jobs:
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
           output="${output//$'\r'/'%0D'}"
-          echo "::set-output name=mongo::$output"
+          echo "mongo=$output" >> $GITHUB_OUTPUT
 
       - name: Test that we don't have an index called ttl
         uses: nick-invision/assert-action@v1
@@ -198,7 +198,7 @@ jobs:
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
           output="${output//$'\r'/'%0D'}"
-          echo "::set-output name=mongo::$output"
+          echo "mongo=$output" >> $GITHUB_OUTPUT
 
       - name: Test that we have something that looks like a cache record
         uses: nick-invision/assert-action@v1
@@ -215,7 +215,7 @@ jobs:
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
           output="${output//$'\r'/'%0D'}"
-          echo "::set-output name=mongo::$output"
+          echo "mongo=$output" >> $GITHUB_OUTPUT
 
       - name: Test that we do have an index called ttl
         uses: nick-invision/assert-action@v1
@@ -237,7 +237,7 @@ jobs:
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
           output="${output//$'\r'/'%0D'}"
-          echo "::set-output name=mongo::$output"
+          echo "mongo=$output" >> $GITHUB_OUTPUT
 
       - name: Test that we have something that looks like a cache record
         uses: nick-invision/assert-action@v1
@@ -254,7 +254,7 @@ jobs:
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
           output="${output//$'\r'/'%0D'}"
-          echo "::set-output name=mongo::$output"
+          echo "mongo=$output" >> $GITHUB_OUTPUT
 
       - name: Test that we do have an index called ttl
         uses: nick-invision/assert-action@v1
@@ -276,7 +276,7 @@ jobs:
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
           output="${output//$'\r'/'%0D'}"
-          echo "::set-output name=mongo::$output"
+          echo "mongo=$output" >> $GITHUB_OUTPUT
 
       - name: Test that we have something that looks like a cache record
         uses: nick-invision/assert-action@v1
@@ -293,7 +293,7 @@ jobs:
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
           output="${output//$'\r'/'%0D'}"
-          echo "::set-output name=mongo::$output"
+          echo "mongo=$output" >> $GITHUB_OUTPUT
 
       - name: Test that we don't have an index called ttl
         uses: nick-invision/assert-action@v1

--- a/.github/workflows/test-roles.yml
+++ b/.github/workflows/test-roles.yml
@@ -29,7 +29,7 @@ jobs:
         id: json-list
         run: |
           output=$(cat int_test_roles.json)
-          echo "::set-output name=roles-to-test::$output"
+          echo "roles-to-test=$output" >> $GITHUB_OUTPUT
           echo "$output"
 
   roles:


### PR DESCRIPTION
##### SUMMARY
Closes #541
Updates old set-output syntax by new one using var `$GITHUB_OUTPUT`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

##### COMPONENT NAME
GitHub CI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
