### PR TITLE
Update ssl_cert_reqs description and option based on pymongo >= 4

### DIFF
--- a/plugins/doc_fragments/ssl_options.py
+++ b/plugins/doc_fragments/ssl_options.py
@@ -16,15 +16,10 @@ options:
       - tls
   ssl_cert_reqs:
     description:
-    - Specifies whether a certificate is required from the other side of the connection,
-      and whether it will be validated if provided.
+    - Bypass validation of server certificate.
     required: no
-    type: str
-    default: 'CERT_REQUIRED'
-    choices:
-      - 'CERT_NONE'
-      - 'CERT_OPTIONAL'
-      - 'CERT_REQUIRED'
+    type: bool
+    default: no
     aliases:
       - tlsAllowInvalidCertificates
   ssl_ca_certs:

--- a/tests/integration/targets/mongodb_monitoring/tasks/main.yml
+++ b/tests/integration/targets/mongodb_monitoring/tasks/main.yml
@@ -57,7 +57,7 @@
     - monitoring.changed == False
     - monitoring.msg == "Free monitoring is already started"
     - monitoring.url is defined
-    - "'https://cloud.mongodb.com/freemonitoring/cluster/' in monitoring.url"
+    - "'https://www.mongodb.com/docs/manual/administration/free-monitoring/' in monitoring.url"
 
 - name: Turn off free monitoring (check mode)
   community.mongodb.mongodb_monitoring:
@@ -193,7 +193,7 @@
     - monitoring.changed == False
     - monitoring.msg == "Free monitoring is already started"
     - monitoring.url is defined
-    - "'https://cloud.mongodb.com/freemonitoring/cluster/' in monitoring.url"
+    - "'https://www.mongodb.com/docs/manual/administration/free-monitoring/' in monitoring.url"
 
 - name: Turn off free monitoring (check mode)
   community.mongodb.mongodb_monitoring:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
On Pymongo 4 migration guide it was mentioned that ssl_cert_reqs now expect a boolean
https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#renamed-uri-options

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix/Docs Pull Request



