### PR TITLE
Omit authenticationRestrictions for mongodb_role if not provided

### DIFF
--- a/plugins/modules/mongodb_role.py
+++ b/plugins/modules/mongodb_role.py
@@ -268,7 +268,7 @@ def role_add(client, db_name, role, privileges, roles, authenticationRestriction
     role_dict["privileges"] = privileges
     role_dict["roles"] = roles
 
-    if role_dict["authenticationRestrictions"]:
+    if role_dict["authenticationRestrictions"] is not None:
       role_dict["authenticationRestrictions"] = authenticationRestrictions
 
     db.command(role_add_db_command, role, **role_dict)


### PR DESCRIPTION
##### SUMMARY

Fixes #575 

This allows documentDB to use this role, by omitting the `authenticationRestrictions` (an [optional parameter](https://www.mongodb.com/docs/manual/reference/method/db.createRole/)) if not explicitly provided. I believe omitting the value sent to mongodb is behaviorally the same as sending `[]`, which is what the previous code did.

This is in a draft state as I haven't worked on the tests, nor manual testing yet.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mongodb_role

##### ADDITIONAL INFORMATION

