### PR TITLE
More robust comparison of user roles

### DIFF
--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -189,7 +189,6 @@ user:
 
 import os
 import traceback
-from operator import itemgetter
 
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
@@ -307,7 +306,7 @@ def check_if_roles_changed(uinfo, roles, db_name):
     roles_as_list_of_dict = make_sure_roles_are_a_list_of_dict(roles, db_name)
     uinfo_roles = uinfo.get('roles', [])
 
-    if sorted(roles_as_list_of_dict, key=itemgetter('db')) == sorted(uinfo_roles, key=itemgetter('db')):
+    if sorted(roles_as_list_of_dict, key=lambda roles: sorted(roles.items())) == sorted(uinfo_roles, key=lambda roles: sorted(roles.items())):
         return False
     return True
 

--- a/tests/unit/test_mongodb_user.py
+++ b/tests/unit/test_mongodb_user.py
@@ -1,0 +1,60 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import unittest
+import sys
+import os
+path = os.path.dirname(os.path.realpath(__file__))
+path = "{0}/../../plugins/modules".format(path)
+sys.path.append(path)
+import mongodb_user
+
+
+class TestMongoDBUserMethods(unittest.TestCase):
+
+    def test_check_if_roles_changed_single_db(self):
+        uinfo = {
+            'roles': [
+                {'db': 'foo', 'role': 'foo'},
+                {'db': 'foo', 'role': 'bar'},
+                {'db': 'foo', 'role': 'baz'},
+            ]
+        }
+        roles_ordered = [
+            'foo',
+            'bar',
+            'baz',
+        ]
+        roles_disordered = [
+            'baz',
+            'bar',
+            'foo',
+        ]
+
+        self.assertFalse(mongodb_user.check_if_roles_changed(uinfo, roles_ordered, 'foo'))
+        self.assertFalse(mongodb_user.check_if_roles_changed(uinfo, roles_disordered, 'foo'))
+
+    def test_check_if_roles_changed_multiple_db(self):
+        uinfo = {
+            'roles': [
+                {'db': 'foo', 'role': 'foo'},
+                {'db': 'foo', 'role': 'bar'},
+                {'db': 'bar', 'role': 'baz'},
+            ]
+        }
+        roles_ordered = [
+            {'db': 'foo', 'role': 'foo'},
+            {'db': 'foo', 'role': 'bar'},
+            {'db': 'bar', 'role': 'baz'},
+        ]
+        roles_disordered = [
+            {'db': 'bar', 'role': 'baz'},
+            {'db': 'foo', 'role': 'bar'},
+            {'db': 'foo', 'role': 'foo'},
+        ]
+
+        self.assertFalse(mongodb_user.check_if_roles_changed(uinfo, roles_ordered, ''))
+        self.assertFalse(mongodb_user.check_if_roles_changed(uinfo, roles_disordered, ''))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY

The current sorting algorithm used to check if user roles has changed make wrong assertions in case of mutiple roles with same "db", because order is not guaranteed, and comparison between actual and expected roles may fails.

See: https://github.com/ansible-collections/community.mongodb/blob/e5512fa1d5d464155d1543377fae615843b9c104/plugins/modules/mongodb_user.py#L310C1-L311C21

Given something like:
```
roles:
  - db: admin
     role: root
  - db: admin
     role: userAdminAnyDatabase
  - db: admin
     role: readWriteAnyDatabase
```

The sorting algorithm may lead to unpredictable results such as:
```
  - db: admin
     role: userAdminAnyDatabase
  - db: admin
     role: root
  - db: admin
     role: readWriteAnyDatabase
...
  - db: admin
     role: readWriteAnyDatabase
  - db: admin
     role: userAdminAnyDatabase
  - db: admin
     role: root
```

Largely inspired by `sort_list` method in ansibe utils (see: https://github.com/ansible-collections/ansible.utils/blob/0d2af1580b356c31d86a56377c87683ce052a024/plugins/module_utils/common/utils.py#L17), this new algorithm is more robust and don't return false positive.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

community.mongodb.mongodb_user

##### ADDITIONAL INFORMATION

