### PR TITLE
Add TLS to mongodb_auth role

### DIFF
--- a/roles/mongodb_auth/defaults/main.yml
+++ b/roles/mongodb_auth/defaults/main.yml
@@ -26,3 +26,5 @@ mongodb_users: []
 # Setting this to yes will result in 'changed' on every run, even if the password is the same.
 # See the comment in tasks/main.yml for more details.
 mongodb_force_update_password: no
+
+mongodb_use_tls: false

--- a/roles/mongodb_auth/tasks/main.yml
+++ b/roles/mongodb_auth/tasks/main.yml
@@ -94,6 +94,8 @@
     database: admin
     roles: "{{ mongodb_admin_roles }}"
 
+    ssl: "{{ mongodb_use_tls }}"
+    ssl_ca_certs: "{{ mongodb_certificate_ca_file if mongodb_use_tls else omit }}"
     login_host: localhost
     login_port: "{{ mongod_port | string }}"  # silence implicit int->str conversion warning
     create_for_localhost_exception: /root/mongodb_admin.success

--- a/roles/mongodb_auth/tasks/mongodb_auth_user.yml
+++ b/roles/mongodb_auth/tasks/mongodb_auth_user.yml
@@ -18,6 +18,8 @@
     database: "{{ _mongodb_user.db }}"
     roles: "{{ _mongodb_user.roles|default('readWrite') }}"
 
+    ssl: "{{ mongodb_use_tls }}"
+    ssl_ca_certs: "{{ mongodb_certificate_ca_file if mongodb_use_tls else omit }}"
     login_host: localhost
     login_port: "{{ mongod_port | string }}"  # silence implicit int->str conversion warning
     login_user: "{{ mongodb_admin_user }}"


### PR DESCRIPTION
##### SUMMARY
I use mongodb with required TLS encryption. To use the mongodb_auth role with encryption I needed to add TLS attributes to community.mongodb.mongodb_user tasks.

##### ISSUE TYPE
- "Feature" Pull Request

##### COMPONENT NAME
mongodb_auth

##### ADDITIONAL INFORMATION
Adding `mongodb_use_tls: false` in role defaults should result the same default behaviour as before, even when not being used in combination with the other roles.
