### PR TITLE
Since Debian 12 (Bookworm), the default NTP system is systemd-timesyncd

### DIFF
--- a/roles/mongodb_linux/vars/Debian-12.yml
+++ b/roles/mongodb_linux/vars/Debian-12.yml
@@ -1,0 +1,5 @@
+---
+# Packages for Debian distros
+ntp_package: systemd-timesyncd
+ntp_service: systemd-timesyncd
+gnu_c_lib: libc6


### PR DESCRIPTION
##### SUMMARY
Since Debian 12 (Bookworm), the default NTP system is systemd-timesyncd

https://www.debian.org/News/2023/20230610
"The ntp package has been replaced with the ntpsec package, with the default system clock service now being systemd-timesyncd; there is also support for chrony and openntpd."

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
role mongodb_linux

