### PR TITLE
variables ntp_package & ntp_service are not usable

### DIFF
--- a/roles/mongodb_linux/README.md
+++ b/roles/mongodb_linux/README.md
@@ -17,8 +17,9 @@ Role Variables
 --------------
 
 swappiness: OS swappiness value. Default "1".
-ntp_package: Name of ntp package. Default ntp.
-ntp_service: Name of ntp service. Default ntpd.
+mongodb_ntp_package: Name of ntp package. Default depends on OS-specific vars.
+mongodb_ntp_service: Name of ntp service. Default depends on OS-specific vars.
+mongodb_gnu_c_lib: Name of the GNU C lib. Default depends on OS-specific vars.
 
 * On RedHat 8 and higher systems ntp_package and ntp_service are set to chrony and chronyd respectively.
 

--- a/roles/mongodb_linux/defaults/main.yml
+++ b/roles/mongodb_linux/defaults/main.yml
@@ -8,3 +8,7 @@ swappiness: "1"
 nproc_and_nofile_limit: 64000
 # TODO: mongo suggests infinity here
 memlock_limit: 1024
+
+mongodb_ntp_package:
+mongodb_ntp_service:
+mongodb_gnu_c_lib:

--- a/roles/mongodb_linux/tasks/main.yml
+++ b/roles/mongodb_linux/tasks/main.yml
@@ -17,6 +17,12 @@
   tags:
     - "vars"
 
+- name: "Override variables from OS-specific configuration"
+  set_fact:
+    ntp_package: "{{ mongodb_ntp_package | default(ntp_package, true) }}"
+    ntp_service: "{{ mongodb_ntp_service | default(ntp_service, true) }}"
+    gnu_c_lib: "{{ mongodb_gnu_c_lib | default(gnu_c_lib, true) }}"
+
 - name: See if we are in docker
   when:
     - "ansible_facts.virtualization_role == 'guest'"


### PR DESCRIPTION
##### SUMMARY
variables ntp_package & ntp_service are not usable (override by OS-specific vars). use mongodb_ntp_package & mongodb_ntp_service instead.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
role mongodb_linux

##### ADDITIONAL INFORMATION
include also mongodb_gnu_c_lib variable, also override by OS-specific vars.