### PR TITLE
Optionnaly install pymongo (and pip)

### DIFF
--- a/roles/mongodb_install/README.md
+++ b/roles/mongodb_install/README.md
@@ -3,11 +3,16 @@ mongodb_install
 
 Install MongoDB packages on Debian and RedHat based platforms. Installs the mongodb-org meta-package which then installs the following packages: mongodb-org-server, mongodb-org-shell, mongodb-org-mongos, mongodb-org-tools.
 
+Optionnaly, this role can install pip & pymongo (pymongo is required for mongodb modules).
+
 Role Variables
 --------------
 
-specific_mongodb_version - Install a specific version of mongodb i.e. 4.4.1. The specified version must be available in the system repositories. By default this variable is undefined.
-mongodb_hold_packages - Runs the lock_mongodb_packages.sh script to either lock mongodb-org packages at a specific version or to release the lock. Set to "HOLD" or "NOHOLD" as desired. No checks are made to see if the hold already exists or not. By default this variable is undefined and the script is not executed. The task is executed at the end and it is possible that packages could be upgraded before the lock is initially applied.
+* `specific_mongodb_version` - Install a specific version of mongodb i.e. 4.4.1. The specified version must be available in the system repositories. By default this variable is undefined.
+* `mongodb_hold_packages` - Runs the lock_mongodb_packages.sh script to either lock mongodb-org packages at a specific version or to release the lock. Set to "HOLD" or "NOHOLD" as desired. No checks are made to see if the hold already exists or not. By default this variable is undefined and the script is not executed. The task is executed at the end and it is possible that packages could be upgraded before the lock is initially applied.
+* `mongodb_install_pymongo` - Install pymongo (and python-pip if not installed). Default no.
+* `mongodb_pip_package_name` - pip package name in the package manager. Default `python3-pip`
+* `mongodb_pip_pymongo_name` - pymongo name in pip. Default `pymongo`
 
 Dependencies
 ------------

--- a/roles/mongodb_install/defaults/main.yml
+++ b/roles/mongodb_install/defaults/main.yml
@@ -1,0 +1,3 @@
+mongodb_install_pymongo: no # set to no for role old version compatibility
+mongodb_pip_package_name: python3-pip
+mongodb_pip_pymongo_name: pymongo

--- a/roles/mongodb_install/tasks/install_pymongo.yml
+++ b/roles/mongodb_install/tasks/install_pymongo.yml
@@ -1,0 +1,16 @@
+---
+- name: Install pip
+  ansible.builtin.package: 
+    name: "{{ mongodb_pip_package_name }}"
+  tags:
+    - "mongodb"
+    - "setup"
+    - "pkg"
+
+- name: Install pymongo
+  ansible.builtin.pip:
+    name: "{{ mongodb_pip_pymongo_name }}"
+  tags:
+    - "mongodb"
+    - "setup"
+    - "pkg"

--- a/roles/mongodb_install/tasks/main.yml
+++ b/roles/mongodb_install/tasks/main.yml
@@ -59,3 +59,11 @@
     - mongodb_hold_packages is defined
   tags:
     - "mongodb"
+
+- name: Install pymongo
+  when: mongodb_install_pymongo
+  ansible.builtin.import_tasks: install_pymongo.yml
+  tags:
+    - "mongodb"
+    - "setup"
+    - "pkg"


### PR DESCRIPTION
##### SUMMARY
Modules need pymongo to work.
This PR add the installation of pymongo and pip, in the role `mongodb_install`
By default, it's not installed for version compatibility. Before installing pymongo, pip is installed.
New ansible variables are documented in the README.md and default values set in `defaults/main.yml`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
role mongodb_install
