### PR TITLE
Optionnaly add logrotate configuration for mongod

### DIFF
--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -29,6 +29,9 @@ Role Variables
 * `mongodb_use_tls`: Wether to use tls. Default false.
 * `mongodb_certificate_key_file`: Path to the PEM-file containing the certficate and private key.
 * `mongodb_certificate_ca_file`:  Path to the CA-file.
+* `mongodb_logrotate_enabled`: Add logrotate configuration. Default: `no`
+* `mongodb_logrotate_template`: Jinja template of the logrotate configuration. Default `mongodb.logrotate.j2` (role builtin logrotate configuration)
+* `mongodb_pid_file`: File that will contain the mongod PID. Default: `/var/run/mongodb/mongod.pid`
 
 IMPORTANT NOTE: It is expected that `mongodb_admin_user` & `mongodb_admin_pwd` values be overridden in your own file protected by Ansible Vault. These values are primary included here for Molecule/Travis CI integration. Any production environments should protect these values. For more information see [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 

--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -31,7 +31,6 @@ Role Variables
 * `mongodb_certificate_ca_file`:  Path to the CA-file.
 * `mongodb_logrotate_enabled`: Add logrotate configuration. Default: `no`
 * `mongodb_logrotate_template`: Jinja template of the logrotate configuration. Default `mongodb.logrotate.j2` (role builtin logrotate configuration)
-* `mongodb_pid_file`: File that will contain the mongod PID. Default: `/var/run/mongodb/mongod.pid`
 
 IMPORTANT NOTE: It is expected that `mongodb_admin_user` & `mongodb_admin_pwd` values be overridden in your own file protected by Ansible Vault. These values are primary included here for Molecule/Travis CI integration. Any production environments should protect these values. For more information see [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -34,3 +34,6 @@ mongod_config_template: "mongod.conf.j2"
 skip_restart: true
 db_path: "{{ '/var/lib/mongodb' if ansible_os_family == 'Debian' else '/var/lib/mongo' if ansible_os_family == 'RedHat' else '/var/lib/mongo' }}"
 mongodb_use_tls: false
+mongodb_logrotate_enabled: no
+mongodb_logrotate_template: "mongodb.logrotate.j2"
+mongodb_pid_file: "/var/run/mongodb/mongod.pid"

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -36,4 +36,3 @@ db_path: "{{ '/var/lib/mongodb' if ansible_os_family == 'Debian' else '/var/lib/
 mongodb_use_tls: false
 mongodb_logrotate_enabled: no
 mongodb_logrotate_template: "mongodb.logrotate.j2"
-mongodb_pid_file: "/var/run/mongodb/mongod.pid"

--- a/roles/mongodb_mongod/tasks/logrotate.yml
+++ b/roles/mongodb_mongod/tasks/logrotate.yml
@@ -1,0 +1,9 @@
+---
+- name: Install logrotate configuration
+  ansible.builtin.template:
+    src: "{{ mongodb_logrotate_template }}"
+    dest: /etc/logrotate.d/mongod
+  tags:
+    - "mongodb"
+    - "setup"
+    - "service"

--- a/roles/mongodb_mongod/tasks/main.yml
+++ b/roles/mongodb_mongod/tasks/main.yml
@@ -37,16 +37,6 @@
     - "mongodb"
     - "setup"
 
-- name: "Ensure PID folder {{ mongodb_pid_file | dirname }} exists"
-  ansible.builtin.file:
-    path: "{{ mongodb_pid_file | dirname }}"
-    state: directory
-    owner: "{{ mongodb_user }}"
-    group: "{{ mongodb_group }}"
-  tags:
-    - "mongodb"
-    - "setup"
-
 - name: Copy config file
   template:
     src: "{{ mongod_config_template }}"

--- a/roles/mongodb_mongod/tasks/main.yml
+++ b/roles/mongodb_mongod/tasks/main.yml
@@ -37,6 +37,16 @@
     - "mongodb"
     - "setup"
 
+- name: "Ensure PID folder {{ mongodb_pid_file | dirname }} exists"
+  ansible.builtin.file:
+    path: "{{ mongodb_pid_file | dirname }}"
+    state: directory
+    owner: "{{ mongodb_user }}"
+    group: "{{ mongodb_group }}"
+  tags:
+    - "mongodb"
+    - "setup"
+
 - name: Copy config file
   template:
     src: "{{ mongod_config_template }}"
@@ -79,6 +89,15 @@
     - "mongodb"
     - "setup"
     - "service"
+
+- name: Configure logrotate if enabled
+  when: mongodb_logrotate_enabled
+  ansible.builtin.include_tasks: logrotate.yml
+  tags:
+    - "mongodb"
+    - "setup"
+    - "service"
+
 # debug section
 - pause:
     seconds: 5

--- a/roles/mongodb_mongod/templates/mongod.conf.j2
+++ b/roles/mongodb_mongod/templates/mongod.conf.j2
@@ -23,8 +23,8 @@ storage:
 processManagement:
 {% if ansible_facts.os_family == "RedHat" and ansible_facts.distribution != "Amazon" and ansible_facts.distribution != "AlmaLinux" and ansible_facts.distribution != "Fedora" %}  # Breaks Ubuntu / Debian
   fork: true
+  pidFilePath: /var/run/mongodb/mongod.pid
 {% endif %}
-  pidFilePath: {{ mongodb_pid_file }}
   timeZoneInfo: /usr/share/zoneinfo
 
 # network interfaces

--- a/roles/mongodb_mongod/templates/mongod.conf.j2
+++ b/roles/mongodb_mongod/templates/mongod.conf.j2
@@ -8,6 +8,9 @@ systemLog:
   destination: file
   logAppend: true
   path: {{ log_path }}
+{% if mongodb_logrotate_enabled %}
+  logRotate: reopen
+{% endif %}
 
 # Where and how to store data.
 storage:
@@ -20,8 +23,8 @@ storage:
 processManagement:
 {% if ansible_facts.os_family == "RedHat" and ansible_facts.distribution != "Amazon" and ansible_facts.distribution != "AlmaLinux" and ansible_facts.distribution != "Fedora" %}  # Breaks Ubuntu / Debian
   fork: true
-  pidFilePath: /var/run/mongodb/mongod.pid
 {% endif %}
+  pidFilePath: {{ mongodb_pid_file }}
   timeZoneInfo: /usr/share/zoneinfo
 
 # network interfaces

--- a/roles/mongodb_mongod/templates/mongodb.logrotate.j2
+++ b/roles/mongodb_mongod/templates/mongodb.logrotate.j2
@@ -9,6 +9,6 @@
   create 640 {{ mongodb_user }} {{ mongodb_group }}
   sharedscripts
   postrotate
-    /bin/kill -SIGUSR1 `cat {{ mongodb_pid_file }} 2>/dev/null` >/dev/null 2>&1
+    /bin/kill -SIGUSR1 `pidof {{ mongod_service }} 2>/dev/null` >/dev/null 2>&1
   endscript
 }

--- a/roles/mongodb_mongod/templates/mongodb.logrotate.j2
+++ b/roles/mongodb_mongod/templates/mongodb.logrotate.j2
@@ -1,0 +1,14 @@
+{{ log_path }} {
+  daily
+  size 100M
+  rotate 5
+  missingok
+  compress
+  delaycompress
+  notifempty
+  create 640 {{ mongodb_user }} {{ mongodb_group }}
+  sharedscripts
+  postrotate
+    /bin/kill -SIGUSR1 `cat {{ mongodb_pid_file }} 2>/dev/null` >/dev/null 2>&1
+  endscript
+}


### PR DESCRIPTION
##### SUMMARY
Add a default logrotate configuration from a jinja template, if `mongodb_logrotate_enabled = yes`
When log rotate is enabled, the signal USR1 (`SIGUSR1`) is used to inform mongod process that the log file have been rotated.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
role mongodb_mongod

##### ADDITIONAL INFORMATION
In the configuration template, the attribute `processManagement.pidFilePath` was moved the `if` condition, the PID file should be set, whatever the OS.
Also, a check was added to ensure that the PID file folder exists.
