### PR TITLE
setup_remote_temp_dir: Set ignore_errors true on delete tempdir handler task

### DIFF
--- a/tests/integration/targets/setup_remote_tmp_dir/tasks/default-cleanup.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/tasks/default-cleanup.yml
@@ -3,3 +3,4 @@
     path: '{{ remote_tmp_dir }}'
     state: absent
   no_log: true
+  ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
Occasional errors happen on the "delete temporary directory". It's safe to ignore these so let's do so.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup_remote_temp_dir
