### PR TITLE
Don't fail if transparent_hugepage is not configured in the kernel

### DIFF
--- a/roles/mongodb_linux/files/thp-disable.service
+++ b/roles/mongodb_linux/files/thp-disable.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Disable Transparent Huge Pages
+ConditionPathIsDirectory=/sys/kernel/mm/transparent_hugepage
 
 [Service]
 Type=oneshot

--- a/roles/mongodb_linux/tasks/main.yml
+++ b/roles/mongodb_linux/tasks/main.yml
@@ -132,8 +132,14 @@
     - "setup"
     - "service"
 
+- name: Check if transparent_hugepage is enabled in the kernel
+  stat:
+    path: /sys/kernel/mm/transparent_hugepage
+  register: sys_thp
+
 - name: Check if disable-transparent-huge-pages service is already run
   shell: cat /sys/kernel/mm/transparent_hugepage/enabled | grep -o '[never]'
+  when: sys_thp.stat.exists
   register: _huge_page_status
   ignore_errors: yes
   changed_when: _huge_page_status.stdout == ""
@@ -147,7 +153,7 @@
     name: disable-transparent-huge-pages
     state: started
     enabled: yes
-  when: (not in_docker|bool) and (_huge_page_status.stdout == "")
+  when: (not in_docker|bool) and (sys_thp.stat.exists) and (_huge_page_status.stdout == "")
   tags:
     - "linux"
     - "service"


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If the kernel does not present /sys/kernel/mm/transparent_hugepage then don't try and write into it or run the service.

Guard the systemd service just in case the kernel config changes after it's been deployed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
