### PR TITLE
Fix specific_mongodb_version option for redhat

### DIFF
--- a/roles/mongodb_install/files/lock_mongodb_packages.sh
+++ b/roles/mongodb_install/files/lock_mongodb_packages.sh
@@ -8,13 +8,19 @@ HOLD="$1";
 PACKAGE_NAME="mongodb-org*"
 
 if [[ "$HOLD" == "HOLD" ]]; then
-  if command -v yum &> /dev/null; then
+  if command -v dnf &> /dev/null; then
+    dnf install "dnf-command(versionlock)"
+    dnf versionlock "$PACKAGE_NAME" && touch /root/mongo_version_lock.success;
+  elif command -v yum &> /dev/null; then
     yum versionlock "$PACKAGE_NAME" && touch /root/mongo_version_lock.success;
   elif command -v apt-mark  &> /dev/null; then
     apt-mark hold "$PACKAGE_NAME" && touch /root/mongo_version_lock.success;
   fi;
 elif [[ "$HOLD" == "NOHOLD" ]]; then
-  if command -v yum &> /dev/null; then
+  if command -v dnf &> /dev/null; then
+    dnf install "dnf-command(versionlock)"
+    dnf versionlock delete "$PACKAGE_NAME" || true && rm -rf /root/mongo_version_lock.success;
+  elif command -v yum &> /dev/null; then
     yum versionlock delete "$PACKAGE_NAME" || true && rm -rf /root/mongo_version_lock.success;
   elif command -v apt-mark  &> /dev/null; then
     apt-mark unhold "$PACKAGE_NAME" && rm -rf /root/mongo_version_lock.success;

--- a/roles/mongodb_install/tasks/main.yml
+++ b/roles/mongodb_install/tasks/main.yml
@@ -31,11 +31,11 @@
 - name: Install MongoDB Packages (Specific version)
   package:
     name:
-      - "mongodb-org={{ specific_mongodb_version }}"
-      - "mongodb-org-server={{ specific_mongodb_version }}"
+      - "mongodb-org-{{ specific_mongodb_version }}"
+      - "mongodb-org-server-{{ specific_mongodb_version }}"
       - "{{ mongosh_package }}"  # variablized due to tls issue
-      - "mongodb-org-mongos={{ specific_mongodb_version }}"
-      - "mongodb-org-tools={{ specific_mongodb_version }}"
+      - "mongodb-org-mongos-{{ specific_mongodb_version }}"
+      - "mongodb-org-tools-{{ specific_mongodb_version }}"
     state: present
   when:
     - specific_mongodb_version is defined


### PR DESCRIPTION
##### SUMMARY

On redhat (yum/dnf), specific version should be mentioned as `mongodb-org-1.2.3`, with a dash between package and version.

Also fix the lock version script for dnf.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Roles monodb_install
<!--- Write the short name of the module, plugin, task or feature below -->

