### PR TITLE
feat: support to security.disabledProtocols

### DIFF
--- a/roles/mongodb_config/README.md
+++ b/roles/mongodb_config/README.md
@@ -25,6 +25,7 @@ replicaset: When enabled add a replication section to the configuration. Default
 * `skip_restart`: If set to `true` will skip restarting mongod service when config file or the keyfile content changes. Default `true`.
 * `db_path`: Path to database data location. Default `/var/lib/mongodb` on Debian based distributions, `/var/lib/mongo` for others.
 * `mongodb_use_tls`: Wether to use tls. Default false.
+* `mongodb_disabled_tls_protocols`: The tls protocols to be disabled. Leave blank to let MongoDB decide which protocols to allow according to the ones available on the system; check the [official docs](https://www.mongodb.com/docs/v6.0/reference/configuration-options/#mongodb-setting-net.tls.disabledProtocols) for details. Default "".
 * `mongodb_certificate_key_file`: Path to the PEM-file containing the certficate and private key.
 * `mongodb_certificate_ca_file`:  Path to the CA-file.
 

--- a/roles/mongodb_config/defaults/main.yml
+++ b/roles/mongodb_config/defaults/main.yml
@@ -32,3 +32,4 @@ mongod_config_template: "configsrv.conf.j2"
 skip_restart: true
 db_path: "{{ '/var/lib/mongodb' if ansible_os_family == 'Debian' else '/var/lib/mongo' if ansible_os_family == 'RedHat' else '/var/lib/mongo' }}"
 mongodb_use_tls: false
+mongodb_disabled_tls_protocols: ""

--- a/roles/mongodb_config/templates/configsrv.conf.j2
+++ b/roles/mongodb_config/templates/configsrv.conf.j2
@@ -41,6 +41,9 @@ net:
     mode: requireTLS
     certificateKeyFile: {{ mongodb_certificate_key_file }}
     CAFile: {{ mongodb_certificate_ca_file }}
+{% if mongodb_disabled_tls_protocols != "" %}
+    disabledProtocols: {{ mongodb_disabled_tls_protocols }}
+{% endif %}
 {% endif %}
 
 {% if authorization == "enabled" %}

--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -27,6 +27,7 @@ Role Variables
 * `skip_restart`: If set to `true` will skip restarting mongod service when config file or the keyfile content changes. Default `true`.
 * `db_path`: Path to database data location. Default `/var/lib/mongodb` on Debian based distributions, `/var/lib/mongo` for others.
 * `mongodb_use_tls`: Wether to use tls. Default false.
+* `mongodb_disabled_tls_protocols`: The tls protocols to be disabled. Leave blank to let MongoDB decide which protocols to allow according to the ones available on the system; check the [official docs](https://www.mongodb.com/docs/v6.0/reference/configuration-options/#mongodb-setting-net.tls.disabledProtocols) for details. Default "".
 * `mongodb_certificate_key_file`: Path to the PEM-file containing the certficate and private key.
 * `mongodb_certificate_ca_file`:  Path to the CA-file.
 

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -34,3 +34,4 @@ mongod_config_template: "mongod.conf.j2"
 skip_restart: true
 db_path: "{{ '/var/lib/mongodb' if ansible_os_family == 'Debian' else '/var/lib/mongo' if ansible_os_family == 'RedHat' else '/var/lib/mongo' }}"
 mongodb_use_tls: false
+mongodb_disabled_tls_protocols: ""

--- a/roles/mongodb_mongod/templates/mongod.conf.j2
+++ b/roles/mongodb_mongod/templates/mongod.conf.j2
@@ -41,6 +41,9 @@ net:
     mode: requireTLS
     certificateKeyFile: {{ mongodb_certificate_key_file }}
     CAFile: {{ mongodb_certificate_ca_file }}
+{% if mongodb_disabled_tls_protocols != "" %}
+    disabledProtocols: {{ mongodb_disabled_tls_protocols }}
+{% endif %}
 {% endif %}
 
 {% if authorization == "enabled" %}

--- a/roles/mongodb_mongos/README.md
+++ b/roles/mongodb_mongos/README.md
@@ -31,6 +31,7 @@ Role Variables
 * `mongos_config_template`: If defined allows to override path to mongod config template with custom configuration. Default "mongos.conf.j2"
 * `skip_restart`: If set to `true` will skip restarting mongos service when config file or the keyfile content changes. Default `true`.
 * `mongodb_use_tls`: Wether to use tls. Default false.
+* `mongodb_disabled_tls_protocols`: The tls protocols to be disabled. Leave blank to let MongoDB decide which protocols to allow according to the ones available on the system; check the [official docs](https://www.mongodb.com/docs/v6.0/reference/configuration-options/#mongodb-setting-net.tls.disabledProtocols) for details. Default "".
 * `mongodb_certificate_key_file`: Path to the PEM-file containing the certficate and private key.
 * `mongodb_certificate_ca_file`:  Path to the CA-file.
 

--- a/roles/mongodb_mongos/defaults/main.yml
+++ b/roles/mongodb_mongos/defaults/main.yml
@@ -31,3 +31,4 @@ net_compressors: null
 mongos_config_template: "mongos.conf.j2"
 skip_restart: true
 mongodb_use_tls: false
+mongodb_disabled_tls_protocols: ""

--- a/roles/mongodb_mongos/templates/mongos.conf.j2
+++ b/roles/mongodb_mongos/templates/mongos.conf.j2
@@ -19,6 +19,9 @@ net:
     mode: requireTLS
     certificateKeyFile: {{ mongodb_certificate_key_file }}
     CAFile: {{ mongodb_certificate_ca_file }}
+{% if mongodb_disabled_tls_protocols != "" %}
+    disabledProtocols: {{ mongodb_disabled_tls_protocols }}
+{% endif %}
 {% endif %}
 sharding:
   configDB: "{{ config_repl_set_name }}/{{ config_servers }}"


### PR DESCRIPTION
##### SUMMARY
Gives the ability to specify whether and what tls protocols must be disabled.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.mongod

##### ADDITIONAL INFORMATION
A new `mongodb_disabled_tls_protocols` input variable that allows to specify the TLS protocols to be disabled, the string format is the one in the [official docs](https://www.mongodb.com/docs/v6.0/reference/configuration-options/#mongodb-setting-net.tls.disabledProtocols) (as per v5.0 and 6.0, no breaking changes).
If the variable is left empty (the default), nothing gets added to the config file and no override configuration is made. 

Usage:
```yaml
- ansible.builtin.include_role:
    name: community.mongodb.mongodb_repository
  vars:
    mongodb_disabled_tls_protocols: "TLS1_0,TLS1_1,TLS1_2"
```
This can be useful to deploy environments for different purposes like more compliance and restrictive ones (i.e. disable tls1.2) and more permissive ones (i.e. enable tls.1.0 for testing or to support legacy components),

