### PR TITLE
feat(mongod): logrotate configuration

### DIFF
--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -30,8 +30,8 @@ Role Variables
 * `mongodb_disabled_tls_protocols`: The tls protocols to be disabled. Leave blank to let MongoDB decide which protocols to allow according to the ones available on the system; check the [official docs](https://www.mongodb.com/docs/v6.0/reference/configuration-options/#mongodb-setting-net.tls.disabledProtocols) for details. Default "".
 * `mongodb_certificate_key_file`: Path to the PEM-file containing the certficate and private key.
 * `mongodb_certificate_ca_file`:  Path to the CA-file.
-* `mongodb_logrotate_enabled`: Add logrotate configuration. Default: `no`
-* `mongodb_logrotate_template`: Jinja template of the logrotate configuration. Default `mongodb.logrotate.j2` (role builtin logrotate configuration)
+* `mongodb_logrotate_enabled`: Add logrotate configuration. Default: `no`.
+* `mongodb_logrotate_template`: Jinja template for the logrotate configuration. Default `mongodb.logrotate.j2`.
 
 IMPORTANT NOTE: It is expected that `mongodb_admin_user` & `mongodb_admin_pwd` values be overridden in your own file protected by Ansible Vault. These values are primary included here for Molecule/Travis CI integration. Any production environments should protect these values. For more information see [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 

--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -32,7 +32,6 @@ Role Variables
 * `mongodb_certificate_ca_file`:  Path to the CA-file.
 * `mongodb_logrotate_enabled`: Add logrotate configuration. Default: `no`
 * `mongodb_logrotate_template`: Jinja template of the logrotate configuration. Default `mongodb.logrotate.j2` (role builtin logrotate configuration)
-* `mongodb_pid_file`: File that will contain the mongod PID. Default: `/var/run/mongodb/mongod.pid`
 
 IMPORTANT NOTE: It is expected that `mongodb_admin_user` & `mongodb_admin_pwd` values be overridden in your own file protected by Ansible Vault. These values are primary included here for Molecule/Travis CI integration. Any production environments should protect these values. For more information see [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 

--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -30,7 +30,7 @@ Role Variables
 * `mongodb_disabled_tls_protocols`: The tls protocols to be disabled. Leave blank to let MongoDB decide which protocols to allow according to the ones available on the system; check the [official docs](https://www.mongodb.com/docs/v6.0/reference/configuration-options/#mongodb-setting-net.tls.disabledProtocols) for details. Default "".
 * `mongodb_certificate_key_file`: Path to the PEM-file containing the certficate and private key.
 * `mongodb_certificate_ca_file`:  Path to the CA-file.
-* `mongodb_logrotate_enabled`: Add logrotate configuration. Default: `no`.
+* `mongodb_logrotate_enabled`: Add logrotate configuration. Default: `false`.
 * `mongodb_logrotate_template`: Jinja template for the logrotate configuration. Default `mongodb.logrotate.j2`.
 
 IMPORTANT NOTE: It is expected that `mongodb_admin_user` & `mongodb_admin_pwd` values be overridden in your own file protected by Ansible Vault. These values are primary included here for Molecule/Travis CI integration. Any production environments should protect these values. For more information see [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)

--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -30,6 +30,9 @@ Role Variables
 * `mongodb_disabled_tls_protocols`: The tls protocols to be disabled. Leave blank to let MongoDB decide which protocols to allow according to the ones available on the system; check the [official docs](https://www.mongodb.com/docs/v6.0/reference/configuration-options/#mongodb-setting-net.tls.disabledProtocols) for details. Default "".
 * `mongodb_certificate_key_file`: Path to the PEM-file containing the certficate and private key.
 * `mongodb_certificate_ca_file`:  Path to the CA-file.
+* `mongodb_logrotate_enabled`: Add logrotate configuration. Default: `no`
+* `mongodb_logrotate_template`: Jinja template of the logrotate configuration. Default `mongodb.logrotate.j2` (role builtin logrotate configuration)
+* `mongodb_pid_file`: File that will contain the mongod PID. Default: `/var/run/mongodb/mongod.pid`
 
 IMPORTANT NOTE: It is expected that `mongodb_admin_user` & `mongodb_admin_pwd` values be overridden in your own file protected by Ansible Vault. These values are primary included here for Molecule/Travis CI integration. Any production environments should protect these values. For more information see [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -37,4 +37,3 @@ mongodb_use_tls: false
 mongodb_disabled_tls_protocols: ""
 mongodb_logrotate_enabled: no
 mongodb_logrotate_template: "mongodb.logrotate.j2"
-mongodb_pid_file: "/var/run/mongodb/mongod.pid"

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -35,3 +35,6 @@ skip_restart: true
 db_path: "{{ '/var/lib/mongodb' if ansible_os_family == 'Debian' else '/var/lib/mongo' if ansible_os_family == 'RedHat' else '/var/lib/mongo' }}"
 mongodb_use_tls: false
 mongodb_disabled_tls_protocols: ""
+mongodb_logrotate_enabled: no
+mongodb_logrotate_template: "mongodb.logrotate.j2"
+mongodb_pid_file: "/var/run/mongodb/mongod.pid"

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -35,5 +35,5 @@ skip_restart: true
 db_path: "{{ '/var/lib/mongodb' if ansible_os_family == 'Debian' else '/var/lib/mongo' if ansible_os_family == 'RedHat' else '/var/lib/mongo' }}"
 mongodb_use_tls: false
 mongodb_disabled_tls_protocols: ""
-mongodb_logrotate_enabled: no
+mongodb_logrotate_enabled: false
 mongodb_logrotate_template: "mongodb.logrotate.j2"

--- a/roles/mongodb_mongod/tasks/logrotate.yml
+++ b/roles/mongodb_mongod/tasks/logrotate.yml
@@ -1,0 +1,9 @@
+---
+- name: Install logrotate configuration
+  ansible.builtin.template:
+    src: "{{ mongodb_logrotate_template }}"
+    dest: /etc/logrotate.d/mongod
+  tags:
+    - "mongodb"
+    - "setup"
+    - "service"

--- a/roles/mongodb_mongod/tasks/main.yml
+++ b/roles/mongodb_mongod/tasks/main.yml
@@ -37,16 +37,6 @@
     - "mongodb"
     - "setup"
 
-- name: "Ensure PID folder {{ mongodb_pid_file | dirname }} exists"
-  ansible.builtin.file:
-    path: "{{ mongodb_pid_file | dirname }}"
-    state: directory
-    owner: "{{ mongodb_user }}"
-    group: "{{ mongodb_group }}"
-  tags:
-    - "mongodb"
-    - "setup"
-
 - name: Copy config file
   template:
     src: "{{ mongod_config_template }}"

--- a/roles/mongodb_mongod/tasks/main.yml
+++ b/roles/mongodb_mongod/tasks/main.yml
@@ -37,6 +37,16 @@
     - "mongodb"
     - "setup"
 
+- name: "Ensure PID folder {{ mongodb_pid_file | dirname }} exists"
+  ansible.builtin.file:
+    path: "{{ mongodb_pid_file | dirname }}"
+    state: directory
+    owner: "{{ mongodb_user }}"
+    group: "{{ mongodb_group }}"
+  tags:
+    - "mongodb"
+    - "setup"
+
 - name: Copy config file
   template:
     src: "{{ mongod_config_template }}"
@@ -79,6 +89,15 @@
     - "mongodb"
     - "setup"
     - "service"
+
+- name: Configure logrotate if enabled
+  when: mongodb_logrotate_enabled
+  ansible.builtin.include_tasks: logrotate.yml
+  tags:
+    - "mongodb"
+    - "setup"
+    - "service"
+
 # debug section
 - pause:
     seconds: 5

--- a/roles/mongodb_mongod/templates/mongod.conf.j2
+++ b/roles/mongodb_mongod/templates/mongod.conf.j2
@@ -23,8 +23,8 @@ storage:
 processManagement:
 {% if ansible_facts.os_family == "RedHat" and ansible_facts.distribution != "Amazon" and ansible_facts.distribution != "AlmaLinux" and ansible_facts.distribution != "Fedora" %}  # Breaks Ubuntu / Debian
   fork: true
+  pidFilePath: /var/run/mongodb/mongod.pid
 {% endif %}
-  pidFilePath: {{ mongodb_pid_file }}
   timeZoneInfo: /usr/share/zoneinfo
 
 # network interfaces

--- a/roles/mongodb_mongod/templates/mongod.conf.j2
+++ b/roles/mongodb_mongod/templates/mongod.conf.j2
@@ -8,6 +8,9 @@ systemLog:
   destination: file
   logAppend: true
   path: {{ log_path }}
+{% if mongodb_logrotate_enabled %}
+  logRotate: reopen
+{% endif %}
 
 # Where and how to store data.
 storage:
@@ -20,8 +23,8 @@ storage:
 processManagement:
 {% if ansible_facts.os_family == "RedHat" and ansible_facts.distribution != "Amazon" and ansible_facts.distribution != "AlmaLinux" and ansible_facts.distribution != "Fedora" %}  # Breaks Ubuntu / Debian
   fork: true
-  pidFilePath: /var/run/mongodb/mongod.pid
 {% endif %}
+  pidFilePath: {{ mongodb_pid_file }}
   timeZoneInfo: /usr/share/zoneinfo
 
 # network interfaces

--- a/roles/mongodb_mongod/templates/mongodb.logrotate.j2
+++ b/roles/mongodb_mongod/templates/mongodb.logrotate.j2
@@ -9,6 +9,6 @@
   create 640 {{ mongodb_user }} {{ mongodb_group }}
   sharedscripts
   postrotate
-    /bin/kill -SIGUSR1 `cat {{ mongodb_pid_file }} 2>/dev/null` >/dev/null 2>&1
+    /bin/kill -SIGUSR1 `pidof {{ mongod_service }} 2>/dev/null` >/dev/null 2>&1
   endscript
 }

--- a/roles/mongodb_mongod/templates/mongodb.logrotate.j2
+++ b/roles/mongodb_mongod/templates/mongodb.logrotate.j2
@@ -1,0 +1,14 @@
+{{ log_path }} {
+  daily
+  size 100M
+  rotate 5
+  missingok
+  compress
+  delaycompress
+  notifempty
+  create 640 {{ mongodb_user }} {{ mongodb_group }}
+  sharedscripts
+  postrotate
+    /bin/kill -SIGUSR1 `cat {{ mongodb_pid_file }} 2>/dev/null` >/dev/null 2>&1
+  endscript
+}


### PR DESCRIPTION
##### SUMMARY
Enables the log rotation feature for mongod (based on @beerfranz work).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mongodb_mongod

##### ADDITIONAL INFORMATION
Two new variables introduced: `mongodb_logrotate_enabled` and `mongodb_logrotate_template`.
This configuration may be useful in different scenarios.
One example could be a replica set configured on self-managed AWS EC2 instances, where you have the Amazon CloudWatch Agents on board, that exports mongod logs in real time on third party services (in that case, CloudWatch), so you don't need to store them in place and the drive space can be freed up. The same applies with other clouders/on-prem infras as well.

As required by @rhysmeister in #591 ([see comment](https://github.com/ansible-collections/community.mongodb/pull/591#issuecomment-1757458852)), this PR fixes the boolean "semantic" values.
The branch has already been rebased on master.

Example usage:
```yaml
- ansible.builtin.include_role:
    name: community.mongodb.mongodb_mongod
  vars:
    mongodb_logrotate_enabled: true
    mongodb_logrotate_template: "/optional/path/to/custom.logrotate.j2"
```

Defaults to `false` so it is completely opt-in.