### PR TITLE
feat: allow connections without certificates

### DIFF
--- a/roles/mongodb_config/README.md
+++ b/roles/mongodb_config/README.md
@@ -6,25 +6,25 @@ A simple role to aid in setting up a CSRS Config Server Replicaset for a MongoDB
 Role Variables
 --------------
 
-* `config_port`: The port used by the mongos process. Default 27019.
-* `mongod_service`: The name of the mongod service. Default mongod.
-* `mongodb_user`: The Linux OS user for MongoDB. Default mongod.
-* `mongodb_group`: The Linux OS user group for MongoDB. Default mongod.
-* `pid_file`: The pid file for mongos. Default /run/mongodb/mongos.pid.
-* `log_path`: Path of the log file. Default /var/log/mongodb/mongod.log.
-* `bind_ip`: The IP address mongod will bind to. Default 0.0.0.0.
-* `bind_ip_all`: Have mongod bind to all IP addresses instead of specifying `bind_ip`. Default false.
-* `config_repl_set_name`: The replicaset name for the config servers. Default cfg.
-* `authorization`: Enable authorization. Default enabled.
+* `config_port`: The port used by the mongos process. Default `27019`.
+* `mongod_service`: The name of the mongod service. Default `mongod`.
+* `mongodb_user`: The Linux OS user for MongoDB. Default `mongod`.
+* `mongodb_group`: The Linux OS user group for MongoDB. Default `mongod`.
+* `pid_file`: The pid file for mongos. Default `/run/mongodb/mongos.pid`.
+* `log_path`: Path of the log file. Default `/var/log/mongodb/mongod.log`.
+* `bind_ip`: The IP address mongod will bind to. Default `0.0.0.0`.
+* `bind_ip_all`: Have mongod bind to all IP addresses instead of specifying `bind_ip`. Default `false`.
+* `config_repl_set_name`: The replicaset name for the config servers. Default `cfg`.
+* `authorization`: Enable authorization. Default `enabled`.
 * `openssl_keyfile_content`: The kexfile content that MongoDB uses to authenticate within a replicaset. Generate with cmd: openssl rand -base64 756.
-* `openssl_keyfile_path`: Put the openssl_keyfile at this path. Default: /etc/keyfile
-* `mongod_package`: The name of the mongod installation package. Default mongodb-org-server.
-replicaset: When enabled add a replication section to the configuration. Default true.
+* `openssl_keyfile_path`: Put the openssl_keyfile at this path. Default: `/etc/keyfile`.
+* `mongod_package`: The name of the mongod installation package. Default `mongodb-org-server`.
+replicaset: When enabled add a replication section to the configuration. Default `true`.
 * `net_compressors`: If this is set, this sets `net.compression.compressors` in mongod.conf.
-* `mongod_config_template`: If defined allows to override path to mongod config template with custom configuration. Default "mongod.conf.j2"
+* `mongod_config_template`: If defined allows to override path to mongod config template with custom configuration. Default `mongod.conf.j2`.
 * `skip_restart`: If set to `true` will skip restarting mongod service when config file or the keyfile content changes. Default `true`.
 * `db_path`: Path to database data location. Default `/var/lib/mongodb` on Debian based distributions, `/var/lib/mongo` for others.
-* `mongodb_use_tls`: Wether to use tls. Default false.
+* `mongodb_use_tls`: Whether to use tls. Default `false`.
 * `mongodb_disabled_tls_protocols`: The tls protocols to be disabled. Leave blank to let MongoDB decide which protocols to allow according to the ones available on the system; check the [official docs](https://www.mongodb.com/docs/v6.0/reference/configuration-options/#mongodb-setting-net.tls.disabledProtocols) for details. Default "".
 * `mongodb_allow_connections_without_certificates`: When enabled allows to bypass the certificate validation for clients that do not present a certificate, if a certificate is provided it _must_ be valid. Default `false`.
 * `mongodb_certificate_key_file`: Path to the PEM-file containing the certficate and private key.

--- a/roles/mongodb_config/README.md
+++ b/roles/mongodb_config/README.md
@@ -26,6 +26,7 @@ replicaset: When enabled add a replication section to the configuration. Default
 * `db_path`: Path to database data location. Default `/var/lib/mongodb` on Debian based distributions, `/var/lib/mongo` for others.
 * `mongodb_use_tls`: Wether to use tls. Default false.
 * `mongodb_disabled_tls_protocols`: The tls protocols to be disabled. Leave blank to let MongoDB decide which protocols to allow according to the ones available on the system; check the [official docs](https://www.mongodb.com/docs/v6.0/reference/configuration-options/#mongodb-setting-net.tls.disabledProtocols) for details. Default "".
+* `mongodb_allow_connections_without_certificates`: When enabled allows to bypass the certificate validation for clients that do not present a certificate, if a certificate is provided it _must_ be valid. Default `false`.
 * `mongodb_certificate_key_file`: Path to the PEM-file containing the certficate and private key.
 * `mongodb_certificate_ca_file`:  Path to the CA-file.
 

--- a/roles/mongodb_config/defaults/main.yml
+++ b/roles/mongodb_config/defaults/main.yml
@@ -33,3 +33,4 @@ skip_restart: true
 db_path: "{{ '/var/lib/mongodb' if ansible_os_family == 'Debian' else '/var/lib/mongo' if ansible_os_family == 'RedHat' else '/var/lib/mongo' }}"
 mongodb_use_tls: false
 mongodb_disabled_tls_protocols: ""
+mongodb_allow_connections_without_certificates: false

--- a/roles/mongodb_config/templates/configsrv.conf.j2
+++ b/roles/mongodb_config/templates/configsrv.conf.j2
@@ -44,6 +44,9 @@ net:
 {% if mongodb_disabled_tls_protocols != "" %}
     disabledProtocols: {{ mongodb_disabled_tls_protocols }}
 {% endif %}
+{% if mongodb_allow_connections_without_certificates %}
+    allowConnectionsWithoutCertificates: true
+{% endif %}
 {% endif %}
 
 {% if authorization == "enabled" %}

--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -28,6 +28,7 @@ Role Variables
 * `db_path`: Path to database data location. Default `/var/lib/mongodb` on Debian based distributions, `/var/lib/mongo` for others.
 * `mongodb_use_tls`: Wether to use tls. Default false.
 * `mongodb_disabled_tls_protocols`: The tls protocols to be disabled. Leave blank to let MongoDB decide which protocols to allow according to the ones available on the system; check the [official docs](https://www.mongodb.com/docs/v6.0/reference/configuration-options/#mongodb-setting-net.tls.disabledProtocols) for details. Default "".
+* `mongodb_allow_connections_without_certificates`: When enabled allows to bypass the certificate validation for clients that do not present a certificate, if a certificate is provided it _must_ be valid. Default `false`.
 * `mongodb_certificate_key_file`: Path to the PEM-file containing the certficate and private key.
 * `mongodb_certificate_ca_file`:  Path to the CA-file.
 * `mongodb_logrotate_enabled`: Add logrotate configuration. Default: `false`.

--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -6,27 +6,27 @@ A simple role to aid in the setup of a MongoDB replicaset.
 Role Variables
 --------------
 
-* `mongod_port`: The port used by the mongod process. Default 27017.
-* `mongod_service`: The name of the mongod service. Default mongod.
-* `mongodb_user`: The Linux OS user for MongoDB. Default mongod.
-* `mongodb_group`: The Linux OS user group for MongoDB. Default mongod.
-* `bind_ip`: The IP address mongod will bind to. Default 0.0.0.0.
-* `bind_ip_all`: Have mongod bind to all IP addresses instead of specifying `bind_ip`. Default false.
-* `log_path`: Path of the log file. Default: /var/log/mongodb/mongod.log.
-* `repl_set_name`: The name of the replicaset the member will participate in. Default rs0.
-* `authorization`: Enable authorization. Default enabled.
+* `mongod_port`: The port used by the mongod process. Default `27017`.
+* `mongod_service`: The name of the mongod service. Default `mongod`.
+* `mongodb_user`: The Linux OS user for MongoDB. Default `mongod`.
+* `mongodb_group`: The Linux OS user group for MongoDB. Default `mongod`.
+* `bind_ip`: The IP address mongod will bind to. Default `0.0.0.0`.
+* `bind_ip_all`: Have mongod bind to all IP addresses instead of specifying `bind_ip`. Default `false`.
+* `log_path`: Path of the log file. Default: `/var/log/mongodb/mongod.log`.
+* `repl_set_name`: The name of the replicaset the member will participate in. Default `rs0`.
+* `authorization`: Enable authorization. Default `enabled`.
 * `openssl_keyfile_content`: The keyfile content that MongoDB uses to authenticate within a replicaset. Generate with cmd: openssl rand -base64 756.
-* `openssl_keyfile_path`: Put the openssl_keyfile at this path. Default: /etc/keyfile
-* `mongodb_admin_user`: MongoDB admin username. Default admin.
-* `mongodb_admin_pwd`: MongoDB admin password. Default admin.
-* `mongod_package`: The mongod package to install. Default mongodb-org-server.
-* `replicaset`: When enabled add a replication section to the configuration. Default true.
-* `sharding`: If this replicaset member will form part of a sharded cluster. Default false.
+* `openssl_keyfile_path`: Put the openssl_keyfile at this path. Default: `/etc/keyfile`.
+* `mongodb_admin_user`: MongoDB admin username. Default `admin`.
+* `mongodb_admin_pwd`: MongoDB admin password. Default `admin`.
+* `mongod_package`: The mongod package to install. Default `mongodb-org-server`.
+* `replicaset`: When enabled add a replication section to the configuration. Default `true`.
+* `sharding`: If this replicaset member will form part of a sharded cluster. Default `false`.
 * `net_compressors`: If this is set, this sets `net.compression.compressors` in mongod.conf.
-* `mongod_config_template`: If defined allows to override path to mongod config template with custom configuration. Default "mongod.conf.j2"
+* `mongod_config_template`: If defined allows to override path to mongod config template with custom configuration. Default `mongod.conf.j2`.
 * `skip_restart`: If set to `true` will skip restarting mongod service when config file or the keyfile content changes. Default `true`.
 * `db_path`: Path to database data location. Default `/var/lib/mongodb` on Debian based distributions, `/var/lib/mongo` for others.
-* `mongodb_use_tls`: Wether to use tls. Default false.
+* `mongodb_use_tls`: Whether to use tls. Default `false`.
 * `mongodb_disabled_tls_protocols`: The tls protocols to be disabled. Leave blank to let MongoDB decide which protocols to allow according to the ones available on the system; check the [official docs](https://www.mongodb.com/docs/v6.0/reference/configuration-options/#mongodb-setting-net.tls.disabledProtocols) for details. Default "".
 * `mongodb_allow_connections_without_certificates`: When enabled allows to bypass the certificate validation for clients that do not present a certificate, if a certificate is provided it _must_ be valid. Default `false`.
 * `mongodb_certificate_key_file`: Path to the PEM-file containing the certficate and private key.

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -35,5 +35,6 @@ skip_restart: true
 db_path: "{{ '/var/lib/mongodb' if ansible_os_family == 'Debian' else '/var/lib/mongo' if ansible_os_family == 'RedHat' else '/var/lib/mongo' }}"
 mongodb_use_tls: false
 mongodb_disabled_tls_protocols: ""
+mongodb_allow_connections_without_certificates: false
 mongodb_logrotate_enabled: false
 mongodb_logrotate_template: "mongodb.logrotate.j2"

--- a/roles/mongodb_mongod/templates/mongod.conf.j2
+++ b/roles/mongodb_mongod/templates/mongod.conf.j2
@@ -47,6 +47,9 @@ net:
 {% if mongodb_disabled_tls_protocols != "" %}
     disabledProtocols: {{ mongodb_disabled_tls_protocols }}
 {% endif %}
+{% if mongodb_allow_connections_without_certificates %}
+    allowConnectionsWithoutCertificates: true
+{% endif %}
 {% endif %}
 
 {% if authorization == "enabled" %}

--- a/roles/mongodb_mongos/README.md
+++ b/roles/mongodb_mongos/README.md
@@ -13,24 +13,24 @@ good idea to mention in this section that the boto package is required.
 Role Variables
 --------------
 
-* `mongos_port`: The port used by the mongos process. Default 27017.
-* `mongos_service`: The name of the mongos service. Default mongos.
-* `mongodb_user`: The Linux OS user for MongoDB. Default mongod.
-* `mongodb_group`: The Linux OS user group for MongoDB. Default mongod.
-* `pid_file`: The pid file for mongos. Default /run/mongodb/mongos.pid.
-* `bind_ip`: The IP address mongos will bind to. Default 0.0.0.0.
-* `bind_ip_all`: Have mongos bind to all IP addresses instead of specifying `bind_ip`. Default false.
-* `log_path`: Path of the log file. Default: /var/log/mongodb/mongos.log.
-* `mypy`: Python interpretor. Default python
-* `mongos_package`: The name of the mongos installation package. Default mongodb-org-mongos.
-* `config_repl_set_name`: The name of the config server replicaset. Default cfg.
+* `mongos_port`: The port used by the mongos process. Default `27017`.
+* `mongos_service`: The name of the mongos service. Default `mongos`.
+* `mongodb_user`: The Linux OS user for MongoDB. Default `mongod`.
+* `mongodb_group`: The Linux OS user group for MongoDB. Default `mongod`.
+* `pid_file`: The pid file for mongos. Default `/run/mongodb/mongos.pid`.
+* `bind_ip`: The IP address mongos will bind to. Default `0.0.0.0`.
+* `bind_ip_all`: Have mongos bind to all IP addresses instead of specifying `bind_ip`. Default `false`.
+* `log_path`: Path of the log file. Default: `/var/log/mongodb/mongos.log`.
+* `mypy`: Python interpretor. Default `python`.
+* `mongos_package`: The name of the mongos installation package. Default `mongodb-org-mongos`.
+* `config_repl_set_name`: The name of the config server replicaset. Default `cfg`.
 * `config_servers`: "config1:27019, config2:27019, config3:27019"
 * `openssl_keyfile_content`: The kexfile content that MongoDB uses to authenticate within a replicaset. Generate with cmd: openssl rand -base64 756.
-* `openssl_keyfile_path`: Put the openssl_keyfile at this path. Default: /etc/keyfile
+* `openssl_keyfile_path`: Put the openssl_keyfile at this path. Default: `/etc/keyfile`.
 * `net_compressors`: If this is set, this sets `net.compression.compressors` in mongos.conf.
-* `mongos_config_template`: If defined allows to override path to mongod config template with custom configuration. Default "mongos.conf.j2"
+* `mongos_config_template`: If defined allows to override path to mongod config template with custom configuration. Default `mongos.conf.j2`.
 * `skip_restart`: If set to `true` will skip restarting mongos service when config file or the keyfile content changes. Default `true`.
-* `mongodb_use_tls`: Wether to use tls. Default false.
+* `mongodb_use_tls`: Whether to use tls. Default `false`.
 * `mongodb_disabled_tls_protocols`: The tls protocols to be disabled. Leave blank to let MongoDB decide which protocols to allow according to the ones available on the system; check the [official docs](https://www.mongodb.com/docs/v6.0/reference/configuration-options/#mongodb-setting-net.tls.disabledProtocols) for details. Default "".
 * `mongodb_allow_connections_without_certificates`: When enabled allows to bypass the certificate validation for clients that do not present a certificate, if a certificate is provided it _must_ be valid. Default `false`.
 * `mongodb_certificate_key_file`: Path to the PEM-file containing the certficate and private key.

--- a/roles/mongodb_mongos/README.md
+++ b/roles/mongodb_mongos/README.md
@@ -32,6 +32,7 @@ Role Variables
 * `skip_restart`: If set to `true` will skip restarting mongos service when config file or the keyfile content changes. Default `true`.
 * `mongodb_use_tls`: Wether to use tls. Default false.
 * `mongodb_disabled_tls_protocols`: The tls protocols to be disabled. Leave blank to let MongoDB decide which protocols to allow according to the ones available on the system; check the [official docs](https://www.mongodb.com/docs/v6.0/reference/configuration-options/#mongodb-setting-net.tls.disabledProtocols) for details. Default "".
+* `mongodb_allow_connections_without_certificates`: When enabled allows to bypass the certificate validation for clients that do not present a certificate, if a certificate is provided it _must_ be valid. Default `false`.
 * `mongodb_certificate_key_file`: Path to the PEM-file containing the certficate and private key.
 * `mongodb_certificate_ca_file`:  Path to the CA-file.
 

--- a/roles/mongodb_mongos/defaults/main.yml
+++ b/roles/mongodb_mongos/defaults/main.yml
@@ -32,3 +32,4 @@ mongos_config_template: "mongos.conf.j2"
 skip_restart: true
 mongodb_use_tls: false
 mongodb_disabled_tls_protocols: ""
+mongodb_allow_connections_without_certificates: false

--- a/roles/mongodb_mongos/templates/mongos.conf.j2
+++ b/roles/mongodb_mongos/templates/mongos.conf.j2
@@ -22,6 +22,9 @@ net:
 {% if mongodb_disabled_tls_protocols != "" %}
     disabledProtocols: {{ mongodb_disabled_tls_protocols }}
 {% endif %}
+{% if mongodb_allow_connections_without_certificates %}
+    allowConnectionsWithoutCertificates: true
+{% endif %}
 {% endif %}
 sharding:
   configDB: "{{ config_repl_set_name }}/{{ config_servers }}"


### PR DESCRIPTION
##### SUMMARY
Gives the ability to specify whether to bypass client certificate validation for clients that do not present a certificate.
Documentation reference [here](https://www.mongodb.com/docs/v6.0/tutorial/configure-ssl/#validate-only-if-a-client-presents-a-certificate).

There are also some README(s) typos fixes and formatting.

##### ISSUE TYPE
- Feature Pull Request
- Docs Pull Request

##### COMPONENT NAME
roles involved: mongod, mongos, config

##### ADDITIONAL INFORMATION
A new `mongodb_allow_connections_without_certificates` configuration variable is introduced.
As per documentation: "In most cases, it is important to ensure that clients present valid certificates. However, if you have clients that cannot present a client certificate or are transitioning to using a certificate, you may only want to validate certificates from clients that present a certificate".
This fix would enable the above mentioned scenarios where the clients involved have different requirements or capabilities.

```yaml
- ansible.builtin.include_role:
    name: community.mongodb.mongodb_mongod
  vars:
    mongodb_allow_connections_without_certificates: true
```

It defaults to `false`, so it is completely opt-in.