### PR TITLE
fix(mongodb_replicaset): Add authentication and direct connection

### DIFF
--- a/plugins/modules/mongodb_replicaset.py
+++ b/plugins/modules/mongodb_replicaset.py
@@ -597,6 +597,7 @@ def main():
 
         if module.check_mode is False:
             try:
+                client = mongo_auth(module, client, directConnection=True)
                 replicaset_add(module, client, replica_set, members,
                                arbiter_at_index, protocol_version,
                                chaining_allowed, heartbeat_timeout_secs,


### PR DESCRIPTION
##### SUMMARY

When authentication is enabled on a MongoDB without Replica Set, the module returns the following error:


```
Unable to create replica_set: Some problem Command replSetInitiate requires authentication, full error: {'ok': 0.0, 'errmsg': 'Command replSetInitiate requires authentication', 'code': 13, 'codeName': 'Unauthorized'} | OrderedDict([('_id', 'cluster1'), ('protocolVersion', 1), ('members', [OrderedDict([('_id', 0), ('host', 'arbiter.*****:27017'), ('arbiterOnly', True)]), OrderedDict([('_id', 1), ('host', 'node1.*****:27017')]), OrderedDict([('_id', 2), ('host', 'node2.*****:27017')]), OrderedDict([('_id', 3), ('host', 'node3.*****:27017'), ('hidden', True), ('votes', 0), ('priority', 0)])]), ('settings', {'chainingAllowed': True, 'electionTimeoutMillis': 10000})])
```


Since PyMongo 4+, directConnection is disabled by default so it must be enabled explicitly when we try to create a replica set or the connection times out.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

mongodb_replicaset