### PR TITLE
fix(mongodb_common): Use SSL constants

### DIFF
--- a/plugins/module_utils/mongodb_common.py
+++ b/plugins/module_utils/mongodb_common.py
@@ -168,9 +168,9 @@ def rename_ssl_option_for_pymongo4(connection_options):
     when the driver use is >= PyMongo 4
     """
     if int(PyMongoVersion[0]) >= 4:
-        if connection_options.get('ssl_cert_reqs', None) == 'CERT_NONE':
-            connection_options['tlsAllowInvalidCertificates'] = False
-        elif connection_options.get('ssl_cert_reqs', None) == 'CERT_REQUIRED':
+        if connection_options.get('ssl_cert_reqs', None) in ('CERT_NONE', ssl_lib.CERT_NONE):
+            connection_options['tlsAllowInvalidCertificates'] = True
+        elif connection_options.get('ssl_cert_reqs', None) in ('CERT_REQUIRED', ssl_lib.CERT_REQUIRED):
             connection_options['tlsAllowInvalidCertificates'] = False
         connection_options.pop('ssl_cert_reqs', None)
         if connection_options.get('ssl_ca_certs', None) is not None:


### PR DESCRIPTION
##### SUMMARY
When the connection options are being renamed to be compatible with PyMongo 4+, the SSL options come with constants from the `ssl` module instead of string.

If `CERT_NONE` is used, the `tlsAllowInvalidCertificates` should be enabled.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
mongodb_common

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Arguments to the `mongodb_replicaset` module,  but it also applies to any module that needs to connect to a local MongoDB instance using TLS without certificate validation (`ssl_cert_reqs` = `CERT_NONE`):

```
{
    "arbiter_at_index": 0,
    "atlas_auth": false,
    "auth_mechanism": null,
    "chaining_allowed": true,
    "cluster_cmd": "hello",
    "connection_options": null,
    "debug": false,
    "election_timeout_millis": 10000,
    "force": false,
    "heartbeat_timeout_secs": 10,
    "login_database": "admin",
    "login_host": "localhost",
    "login_password": null,
    "login_port": 27017,
    "login_user": null,
    "max_time_ms": null,
    "members": [
        {
            "host": "***arbiter***"
        },
        {
            "host": "***node1***"
        },
        {
            "host": "***node2***",
        },
        {
            "hidden": true,
            "host": "***node3***",
            "priority": 0,
            "votes": 0
        }
    ],
    "protocol_version": 1,
    "reconfigure": false,
    "replica_set": "cluster1",
    "ssl": true,
    "ssl_ca_certs": null,
    "ssl_cert_reqs": "CERT_NONE",
    "ssl_certfile": null,
    "ssl_crlfile": null,
    "ssl_keyfile": null,
    "ssl_pem_passphrase": null,
    "strict_compatibility": true,
    "validate": true
}
```

Error detected:

> Unable to connect to query replicaset: localhost:27017: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'localhost'. (_ssl.c:1123) (configured timeouts: socketTimeoutMS: 20000.0ms, connectTimeoutMS: 20000.0ms), Timeout: 30s, Topology Description: <TopologyDescription id: 658aa38dd7a21d2cdef09d4b, topology_type: Single, servers: [<ServerDescription ('localhost', 27017) server_type: Unknown, rtt: None, error=AutoReconnect("localhost:27017: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'localhost'. (_ssl.c:1123) (configured timeouts: socketTimeoutMS: 20000.0ms, connectTimeoutMS: 20000.0ms)")>]>

This commit allows the modules to connect successfully.