### PR TITLE
Able to override systemd configuration.

### DIFF
--- a/roles/mongodb_mongod/README.md
+++ b/roles/mongodb_mongod/README.md
@@ -33,6 +33,7 @@ Role Variables
 * `mongodb_certificate_ca_file`:  Path to the CA-file.
 * `mongodb_logrotate_enabled`: Add logrotate configuration. Default: `false`.
 * `mongodb_logrotate_template`: Jinja template for the logrotate configuration. Default `mongodb.logrotate.j2`.
+* `mongodb_systemd_service_override`: Content of a file to override systemd configuration.
 
 IMPORTANT NOTE: It is expected that `mongodb_admin_user` & `mongodb_admin_pwd` values be overridden in your own file protected by Ansible Vault. These values are primary included here for Molecule/Travis CI integration. Any production environments should protect these values. For more information see [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -38,3 +38,10 @@ mongodb_disabled_tls_protocols: ""
 mongodb_allow_connections_without_certificates: false
 mongodb_logrotate_enabled: false
 mongodb_logrotate_template: "mongodb.logrotate.j2"
+
+# Override systemd default configuration
+# Examples:
+# mongodb_systemd_service_override: |
+#   [Service]
+#   Restart=on-failure # Mongod will restart on-failure (by default mongod don't restart)
+mongodb_systemd_service_override: ""

--- a/roles/mongodb_mongod/defaults/main.yml
+++ b/roles/mongodb_mongod/defaults/main.yml
@@ -40,6 +40,7 @@ mongodb_logrotate_enabled: false
 mongodb_logrotate_template: "mongodb.logrotate.j2"
 
 # Override systemd default configuration
+# Some properties are not overridden: https://askubuntu.com/questions/659267/how-do-i-override-or-configure-systemd-services
 # Examples:
 # mongodb_systemd_service_override: |
 #   [Service]

--- a/roles/mongodb_mongod/handlers/main.yml
+++ b/roles/mongodb_mongod/handlers/main.yml
@@ -12,3 +12,8 @@
     host: "{{ bind_ip | split(',') | first }}"
     port: "{{ mongod_port }}"
   when: not skip_restart
+
+- name: Reload systemd configuration
+  listen: daemon-reload
+  systemd:
+    daemon_reload: true

--- a/roles/mongodb_mongod/tasks/main.yml
+++ b/roles/mongodb_mongod/tasks/main.yml
@@ -64,6 +64,30 @@
     - "mongodb"
     - "setup"
 
+- name: Override mongod service
+  when: mongodb_systemd_service_override | length > 0
+  tags:
+    - "mongodb"
+    - "setup"
+    - "service"
+  block:
+  - name: "Create {{ mongod_service }}.service.d directory"
+    file:
+      path: "/etc/systemd/system/{{ mongod_service }}.service.d/"
+      state: directory
+      owner: root
+      group: root
+      mode: 0755
+
+  - name: Override mongod service from provided content
+    copy:
+      content: "{{ mongodb_systemd_service_override }}"
+      dest: "/etc/systemd/system/{{ mongod_service }}.service.d/override.conf"
+      owner: root
+      group: root
+      mode: 0644
+    notify: daemon-reload
+
 - name: Check for github override
   set_fact:
     x_github_override: "{{ lookup('env', 'X_GITHUB_OVERRIDE') | default('0', True) }}"


### PR DESCRIPTION
##### SUMMARY

Add a variable `mongodb_systemd_service_override`, empty by default.

If the variable is not empty, it will put its content in the file `/etc/systemd/system/mongod.service.d/override.conf`.

After a `daemon-reload` (using ansible handlers), the content of this file override the default systemd configuration installed with apt or yum.

In my case, it was to add automatic restart of mongod when it fails, but you can override other values.

```
mongodb_systemd_service_override: |
  [Service]
  Restart=on-failure
```

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

ansible role mongodb_mongod

##### ADDITIONAL INFORMATION

The handler for systemd daemon-reload is also added.