### PR TITLE
mongodb_replicaset: CI TestsWait for rs to stabilize

### DIFF
--- a/tests/integration/targets/mongodb_replicaset/tasks/330_no_auth.yml
+++ b/tests/integration/targets/mongodb_replicaset/tasks/330_no_auth.yml
@@ -84,6 +84,13 @@
       that:
         - rs.changed == True
 
+  - name: Wait for the replicaset to stabilise 
+    community.mongodb.mongodb_status:
+      <<: *mongo_parameters
+      replica_set: "{{ current_replicaset }}"
+      poll: 5
+      interval: 30
+
   - name: Remove a member from the replicaset
     community.mongodb.mongodb_replicaset:
       <<: *mongo_parameters


### PR DESCRIPTION
##### SUMMARY
Adds wait to tests before tailing removial off an RS member... 

https://github.com/ansible-collections/community.mongodb/actions/runs/7895896232/job/21549291337#step:8:35660

> TASK [mongodb_replicaset : Remove a member from the replicaset] ****************
> fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed reconfiguring replicaset New config is rejected :: caused by :: replSetReconfig should only be run on a writable PRIMARY. Current state SECONDARY;, full error: {'topologyVersion': {'processId': ObjectId('65cc358360e0b44d23f516cc'), 'counter': 5}, 'ok': 0.0, 'errmsg': 'New config is rejected :: caused by :: replSetReconfig should only be run on a writable PRIMARY. Current state SECONDARY;', 'code': 10107, 'codeName': 'NotWritablePrimary', '$clusterTime': {'clusterTime': Timestamp(1707881873, 6), 'signature': {'hash': b'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00', 'keyId': 0}}, 'operationTime': Timestamp(1707881873, 6)}, config doc {'_id': 'test_member_add_remove', 'version': 2, 'term': 1, 'members': [{'_id': 0, 'host': 'localhost:3001', 'arbiterOnly': False, 'buildIndexes': True, 'hidden': False, 'priority': 1.0, 'tags': {}, 'secondaryDelaySecs': 0, 'votes': 1}, {'_id': 1, 'host': 'localhost:3002', 'arbiterOnly': False, 'buildIndexes': True, 'hidden': False, 'priority': 1.0, 'tags': {}, 'secondaryDelaySecs': 0, 'votes': 1}], 'protocolVersion': 1, 'writeConcernMajorityJournalDefault': True, 'settings': {'chainingAllowed': True, 'heartbeatIntervalMillis': 2000, 'heartbeatTimeoutSecs': 10, 'electionTimeoutMillis': 10000, 'catchUpTimeoutMillis': -1, 'catchUpTakeoverDelayMillis': 30000, 'getLastErrorModes': {}, 'getLastErrorDefaults': {'w': 1, 'wtimeout': 0}, 'replicaSetId': ObjectId('65cc358560e0b44d23f516df')}}"}

##### ISSUE TYPE
- Bugfix Pull Request
