### PR TITLE
Add test condition for storage option in mongod.conf

### DIFF
--- a/roles/mongodb_mongod/templates/mongod.conf.j2
+++ b/roles/mongodb_mongod/templates/mongod.conf.j2
@@ -15,8 +15,10 @@ systemLog:
 # Where and how to store data.
 storage:
   dbPath: {{ db_path }}
+{% if mongodb_version < '6.1' %}
   journal:
     enabled: true
+{% endif %}
   engine: "wiredTiger"
 
 # how the process runs


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Since mongo 6.1 the storage.journal.enabled option no longer exist, the current state of the template cause a crash when starting mongo 7

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mongodb_mongod Copy config file

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
