### PR TITLE
Fix transparent page grep

### DIFF
--- a/roles/mongodb_linux/tasks/main.yml
+++ b/roles/mongodb_linux/tasks/main.yml
@@ -138,7 +138,7 @@
   register: sys_thp
 
 - name: Check if disable-transparent-huge-pages service is already run
-  shell: cat /sys/kernel/mm/transparent_hugepage/enabled | grep -o '[never]'
+  shell: cat /sys/kernel/mm/transparent_hugepage/enabled | grep -o '\[never\]'
   when: sys_thp.stat.exists
   register: _huge_page_status
   ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
"[" char should be escaped in the grep command or else it will print every char even when transparent page is set to always:


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.mongodb.mongodb_linux
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Content of test file 
```
$ cat /tmp/never 
[always] never
```

```
$ grep -o '[never]' /tmp/never 
n
e
v
e
r
```

```
$ grep -o '\[never\]' /tmp/never
$
```
