### PR TITLE
doc(tests): Add community.crypto collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ cd git/ansible_collections/community
 ```bash
 git clone  https://github.com/ansible-collections/community.mongodb.git ./mongodb
 git clone  https://github.com/ansible-collections/community.general.git ./general
+git clone  https://github.com/ansible-collections/community.crypto.git ./crypto
 ```
 
 * Create and activate a virtual environment.


### PR DESCRIPTION
##### SUMMARY
An community.crypto.openssl_privatekey is required to run integration tests. This commit adds this dependency in the README to fix the following issue:

```
TASK [mongodb_shard : include_tasks] *******************************************
ERROR! couldn't resolve module/action 'openssl_privatekey'. This often indicates a misspelling, missing collection, or incorrect module path.

The error appears to be in '/root/ansible_collections/community/mongodb/tests/output/.tmp/integration/mongodb_shard-dqd6hin9-ÅÑŚÌβŁÈ/tests/integration/targets/mongodb_shard/tasks/create_ssl_certs.yml': line 1, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

- name: generate openssl keys
  ^ here
```

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
README