### PR TITLE
[646] make create_for_localhost_exception configurable

### DIFF
--- a/roles/mongodb_auth/README.md
+++ b/roles/mongodb_auth/README.md
@@ -7,9 +7,11 @@ If your mongo instance requires ssl or an alternative auth_mechanism, please use
 to provide the default auth details for `community.mongodb.mongodb_user` (these defaults are ignored
 when adding the initial admin user with the localhost exception).
 
-If running this on a MongoDB server that already has an admin user (ie when using this role to audit
-an alternate install method), you must touch `/root/mongodb_admin.success` or you will get an error
-when this role tries to add the admin user again.
+By default this role checks and creates a file at `/root/mongodb_admin.success` to provide idempotent creation of the first admin user.
+
+- If running this on a MongoDB server that already has an admin user (ie when using this role to audit
+an alternate install method), you must touch the file or you will get an error when this role tries to add the admin user again.
+- When setting up a fresh MongoDB installation on a system previously configured with this role, remember to delete this file. 
 
 Role Variables
 --------------
@@ -24,6 +26,7 @@ Role Variables
 * `mongodb_admin_default_pwd`: MongoDB admin password (for parent roles to override without overriding user's password). Default admin.
 * `mongodb_users`: List of additional users to add. Each user dict should include fields: db, user, pwd, state (default: "present"), roles (default: "readWrite").
 * `mongodb_force_update_password`: Whether or not to force a password update for any users in mongodb_users. Setting this to yes will result in 'changed' on every run, even if the password is the same. Setting this to no only adds a password when creating the user.
+* `mongodb_create_for_localhost_exception`: Path of the file checked before creating the first admin user. If present, it is skipped. If absent, admin is added and the file is created afterwards. Default `/root/mongodb_admin.success`.
 
 IMPORTANT NOTE: It is expected that mongodb_admin_user & mongodb_admin_pwd values be overridden in your own file protected by Ansible Vault. Any production environments should protect these values. For more information see [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 

--- a/roles/mongodb_auth/defaults/main.yml
+++ b/roles/mongodb_auth/defaults/main.yml
@@ -28,3 +28,5 @@ mongodb_users: []
 mongodb_force_update_password: no
 
 mongodb_use_tls: false
+
+mongodb_create_for_localhost_exception: /root/mongodb_admin.success

--- a/roles/mongodb_auth/tasks/main.yml
+++ b/roles/mongodb_auth/tasks/main.yml
@@ -98,7 +98,7 @@
     ssl_ca_certs: "{{ mongodb_certificate_ca_file if mongodb_use_tls else omit }}"
     login_host: localhost
     login_port: "{{ mongod_port | string }}"  # silence implicit int->str conversion warning
-    create_for_localhost_exception: /root/mongodb_admin.success
+    create_for_localhost_exception: "{{ mongodb_create_for_localhost_exception }}"
   tags:
     - "mongodb"
     - "setup"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #646

Add possibility to override the default location of create_for_localhost_exception file. Update README to be more specific
about the file's purpose.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`mongodb_auth` role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

