### PR TITLE
Update the docs to mention that minimum pymongo version is 4 and fix links

### DIFF
--- a/docs/mongodb_module.template.py
+++ b/docs/mongodb_module.template.py
@@ -25,8 +25,8 @@ options:
     default: <DEFAULT>
 
 notes:
-- Requires the pymongo Python package on the remote host, version 2.4.2+. This
-  can be installed using pip or the OS package manager. @see U(http://api.mongodb.org/python/current/installation.html)
+- Requires the pymongo Python package on the remote host, version 4+. This
+  can be installed using pip or the OS package manager. @see U(https://www.mongodb.com/docs/languages/python/pymongo-driver/current/get-started/download-and-install/)
 requirements:
 - pymongo
 '''

--- a/plugins/cache/mongodb.py
+++ b/plugins/cache/mongodb.py
@@ -129,7 +129,7 @@ class CacheModule(BaseCacheModule):
     def _collection(self):
         '''
         This is a context manager for opening and closing mongo connections as needed. This exists as to not create a global
-        connection, due to pymongo not being fork safe (http://api.mongodb.com/python/current/faq.html#is-pymongo-fork-safe)
+        connection, due to pymongo not being fork safe (https://www.mongodb.com/docs/languages/python/pymongo-driver/current/faq/#is-pymongo-fork-safe-)
         '''
         mongo = pymongo.MongoClient(self._connection)
         try:

--- a/plugins/lookup/mongodb.py
+++ b/plugins/lookup/mongodb.py
@@ -73,11 +73,11 @@ options:
         description:
             - Extra connection parameters that to be sent to pymongo.MongoClient
             - Check the example to see how to connect to mongo using an SSL certificate.
-            - "All possible parameters are here: U(https://api.mongodb.com/python/current/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient)"
+            - "All possible parameters are here: U(https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient)"
         type: dict
         default: {}
 notes:
-    - "Please check https://api.mongodb.org/python/current/api/pymongo/collection.html?highlight=find#pymongo.collection.Collection.find for more details."
+    - "Please check https://pymongo.readthedocs.io/en/stable/api/pymongo/collection.html#pymongo.collection.Collection.find for more details."
 requirements:
     - pymongo >= 2.4 (python library)
 '''

--- a/plugins/modules/mongodb_balancer.py
+++ b/plugins/modules/mongodb_balancer.py
@@ -65,8 +65,8 @@ options:
     type: raw
     required: false
 notes:
-  - Requires the pymongo Python package on the remote host, version 2.4.2+. This
-    can be installed using pip or the OS package manager. @see U(http://api.mongodb.org/python/current/installation.html)
+  - Requires the pymongo Python package on the remote host, version 4+. This
+    can be installed using pip or the OS package manager. @see U(https://www.mongodb.com/docs/languages/python/pymongo-driver/current/get-started/download-and-install/)
 requirements:
   - pymongo
 '''

--- a/plugins/modules/mongodb_index.py
+++ b/plugins/modules/mongodb_index.py
@@ -39,7 +39,7 @@ options:
       - Replica set to connect to (automatically connects to primary for writes).
     type: str
 notes:
-    - Requires the pymongo Python package on the remote host, version 2.4.2+.
+    - Requires the pymongo Python package on the remote host, version 4+.
 
 requirements:
   - pymongo

--- a/plugins/modules/mongodb_info.py
+++ b/plugins/modules/mongodb_info.py
@@ -38,7 +38,7 @@ options:
     elements: str
 
 notes:
-    - Requires the pymongo Python package on the remote host, version 2.4.2+.
+    - Requires the pymongo Python package on the remote host, version 4+.
 
 requirements:
   - pymongo

--- a/plugins/modules/mongodb_maintenance.py
+++ b/plugins/modules/mongodb_maintenance.py
@@ -29,8 +29,8 @@ options:
     type: bool
     default: false
 notes:
-  - Requires the pymongo Python package on the remote host, version 2.4.2+. This
-    can be installed using pip or the OS package manager. @see U(http://api.mongodb.org/python/current/installation.html)
+  - Requires the pymongo Python package on the remote host, version 4+. This
+    can be installed using pip or the OS package manager. @see U(https://www.mongodb.com/docs/languages/python/pymongo-driver/current/get-started/download-and-install/)
 requirements:
   - pymongo
 '''

--- a/plugins/modules/mongodb_oplog.py
+++ b/plugins/modules/mongodb_oplog.py
@@ -38,8 +38,8 @@ options:
     default: false
     required: false
 notes:
-  - Requires the pymongo Python package on the remote host, version 2.4.2+. This
-    can be installed using pip or the OS package manager. @see U(http://api.mongodb.org/python/current/installation.html)
+  - Requires the pymongo Python package on the remote host, version 4+. This
+    can be installed using pip or the OS package manager. @see U(https://www.mongodb.com/docs/languages/python/pymongo-driver/current/get-started/download-and-install/)
 requirements:
   - pymongo
 '''

--- a/plugins/modules/mongodb_parameter.py
+++ b/plugins/modules/mongodb_parameter.py
@@ -46,9 +46,9 @@ options:
         choices: [int, str]
 
 notes:
-    - Requires the pymongo Python package on the remote host, version 2.4.2+.
+    - Requires the pymongo Python package on the remote host, version 4+.
     - This can be installed using pip or the OS package manager.
-    - See also U(http://api.mongodb.org/python/current/installation.html)
+    - See also U(https://www.mongodb.com/docs/languages/python/pymongo-driver/current/get-started/download-and-install/)
 requirements: [ "pymongo" ]
 author: "Loic Blot (@nerzhul)"
 '''

--- a/plugins/modules/mongodb_replicaset.py
+++ b/plugins/modules/mongodb_replicaset.py
@@ -111,8 +111,8 @@ options:
       - hello
     default: hello
 notes:
-- Requires the pymongo Python package on the remote host, version 2.4.2+. This
-  can be installed using pip or the OS package manager. @see U(http://api.mongodb.org/python/current/installation.html)
+- Requires the pymongo Python package on the remote host, version 4+. This
+  can be installed using pip or the OS package manager. @see U(https://www.mongodb.com/docs/languages/python/pymongo-driver/current/get-started/download-and-install/)
 requirements:
 - pymongo
 '''

--- a/plugins/modules/mongodb_role.py
+++ b/plugins/modules/mongodb_role.py
@@ -79,9 +79,9 @@ options:
     default: false
     type: bool
 notes:
-    - Requires the pymongo Python package on the remote host, version 2.4.2+. This
+    - Requires the pymongo Python package on the remote host, version 4+. This
       can be installed using pip or the OS package manager. Newer mongo server versions require newer
-      pymongo versions. @see http://api.mongodb.org/python/current/installation.html
+      pymongo versions. @see https://www.mongodb.com/docs/languages/python/pymongo-driver/current/compatibility/
 requirements:
   - "pymongo"
 author:

--- a/plugins/modules/mongodb_schema.py
+++ b/plugins/modules/mongodb_schema.py
@@ -84,7 +84,7 @@ options:
     default: false
 
 notes:
-    - Requires the pymongo Python package on the remote host, version 2.4.2+.
+    - Requires the pymongo Python package on the remote host, version 4+.
 
 requirements:
   - pymongo

--- a/plugins/modules/mongodb_shard.py
+++ b/plugins/modules/mongodb_shard.py
@@ -54,7 +54,7 @@ options:
       - "present"
 
 notes:
-    - Requires the pymongo Python package on the remote host, version 2.4.2+.
+    - Requires the pymongo Python package on the remote host, version 4+.
 requirements: [ pymongo ]
 '''
 

--- a/plugins/modules/mongodb_shard_tag.py
+++ b/plugins/modules/mongodb_shard_tag.py
@@ -49,8 +49,8 @@ options:
     type: str
     default: "mongos"
 notes:
-  - Requires the pymongo Python package on the remote host, version 2.4.2+. This
-    can be installed using pip or the OS package manager. @see U(http://api.mongodb.org/python/current/installation.html)
+  - Requires the pymongo Python package on the remote host, version 4+. This
+    can be installed using pip or the OS package manager. @see U(https://www.mongodb.com/docs/languages/python/pymongo-driver/current/get-started/download-and-install/)
 requirements:
   - pymongo
 '''

--- a/plugins/modules/mongodb_shard_zone.py
+++ b/plugins/modules/mongodb_shard_zone.py
@@ -54,8 +54,8 @@ options:
     type: str
     default: "mongos"
 notes:
-  - Requires the pymongo Python package on the remote host, version 2.4.2+. This
-    can be installed using pip or the OS package manager. @see U(http://api.mongodb.org/python/current/installation.html)
+  - Requires the pymongo Python package on the remote host, version 4+. This
+    can be installed using pip or the OS package manager. @see U(https://www.mongodb.com/docs/languages/python/pymongo-driver/current/get-started/download-and-install/)
 requirements:
   - pymongo
 '''

--- a/plugins/modules/mongodb_shutdown.py
+++ b/plugins/modules/mongodb_shutdown.py
@@ -33,8 +33,8 @@ options:
     type: int
     default: 10
 notes:
-- Requires the pymongo Python package on the remote host, version 2.4.2+. This
-  can be installed using pip or the OS package manager. @see U(http://api.mongodb.org/python/current/installation.html)
+- Requires the pymongo Python package on the remote host, version 4+. This
+  can be installed using pip or the OS package manager. @see U(https://www.mongodb.com/docs/languages/python/pymongo-driver/current/get-started/download-and-install/)
 requirements:
   - pymongo
 '''

--- a/plugins/modules/mongodb_status.py
+++ b/plugins/modules/mongodb_status.py
@@ -57,8 +57,8 @@ options:
        - minimal
     default: default
 notes:
-- Requires the pymongo Python package on the remote host, version 2.4.2+. This
-  can be installed using pip or the OS package manager. @see U(http://api.mongodb.org/python/current/installation.html)
+- Requires the pymongo Python package on the remote host, version 4+. This
+  can be installed using pip or the OS package manager. @see U(https://www.mongodb.com/docs/languages/python/pymongo-driver/current/get-started/download-and-install/)
 requirements:
 - pymongo
 '''

--- a/plugins/modules/mongodb_stepdown.py
+++ b/plugins/modules/mongodb_stepdown.py
@@ -52,8 +52,8 @@ options:
     type: bool
     default: false
 notes:
-  - Requires the pymongo Python package on the remote host, version 2.4.2+. This
-    can be installed using pip or the OS package manager. @see U(http://api.mongodb.org/python/current/installation.html)
+  - Requires the pymongo Python package on the remote host, version 4+. This
+    can be installed using pip or the OS package manager. @see U(https://www.mongodb.com/docs/languages/python/pymongo-driver/current/get-started/download-and-install/)
 requirements:
   - pymongo
 '''

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -79,9 +79,9 @@ options:
       - If this file is present (and C(login_user) is not defined), then skip this task.
 
 notes:
-    - Requires the pymongo Python package on the remote host, version 2.4.2+. This
+    - Requires the pymongo Python package on the remote host, version 4+. This
       can be installed using pip or the OS package manager. Newer mongo server versions require newer
-      pymongo versions. @see http://api.mongodb.org/python/current/installation.html
+      pymongo versions. @see https://www.mongodb.com/docs/languages/python/pymongo-driver/current/compatibility/
 requirements:
   - "pymongo"
 author:


### PR DESCRIPTION
Update the docs to mention that minimum pymongo version is 4 and fix broken links

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The documentation mentions that pymongo 2.4.2+ is supported, but the code checks for 4+. This fixes that. This also fix the broken api.mongodb.org and api.mongodeb.com links.

Fixes #581
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.mongodb collection

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This fixes the obvious documentation issue of showing that 2.4.2+ might work while the code checks for 4+.

It also fixes several broken links.

This does not touch the code doing the work, since I don't have enough of a test env for an up to date Ansible version. (the code has related issues - there are lots of redundant version checks and messages mentioning much older pymongo requirements and `is_auth_enabled` crashes on older pymongo versions before the version check telling the users that 4+ is required is run. (that is not covered by this PR.
