### PR TITLE
Updating mongodb packages to latest version

### DIFF
--- a/roles/mongodb_mongod/tasks/main.yml
+++ b/roles/mongodb_mongod/tasks/main.yml
@@ -19,9 +19,12 @@
 - name: Ensure mongod package is installed
   package:
     name: "{{ mongod_package }}"
+    state: "{{ mongod_package_state | d('present') }}"
   register: _pkg
   until: _pkg is succeeded
   retries: 5
+  notify:
+    - Restart mongod service
   tags:
     - "mongodb"
     - "pkg"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
After having installed and configured mongodb for over a year with this collection, I wanted to upgrade to version 7.0.

There are several ways to achieve this in general, but I wanted to use the collection if possible. The only way i saw was specifying a `specific_mongodb_version`.  

I added a variable mongod_package_state to be used as state for the package task (Ensure mongod package is installed). This only works for package manager allowing to set the state to latest (I use debian/ubuntu).

This works for me, but may not be the best solution. My problem with this solution is, that mongodb_install notifies a handler defined in mongodb_mongod, which works, but is not really good style. And when using Mongos, a restart of the daemon would also be necessary.

Maybe there is a better / easier way. I'm open to ideas

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mongodb_install

##### ADDITIONAL INFORMATION
An upgrade playbook could be like this:
```
- hosts: mongodb
  serial: 1
  collections: community.mongodb
  vars:
    - mongod_package_state: latest
  pre_tasks:
    - name: remove old mongodb-mongosh package
      ansible.builtin.package:
        name: mongodb-mongosh
        state: absent
  roles:
    - role: mongodb_repository
      tags: ['mongodb_base']
    - role: mongodb_linux
      tags: ['mongodb_base']
    - role: mongodb_install
      tags: ['mongodb_base']
    - role: mongodb_mongod
      tags: ['mongodb']
```
