### PR TITLE
Change apt_key_url to avoid redirection and possible play failure

### DIFF
--- a/roles/mongodb_repository/defaults/main.yml
+++ b/roles/mongodb_repository/defaults/main.yml
@@ -5,7 +5,7 @@ debian_packages:
   - curl
   - gnupg
 debian:
-  apt_key_url: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"
+  apt_key_url: "https://pgp.mongodb.com/server-{{ mongodb_version }}.asc"
   apt_repository_repo: "deb{{ ' [ arch=amd64,arm64 ]' if ansible_facts.distribution == 'Ubuntu' else '' }} https://repo.mongodb.org/apt/{{ ansible_facts.distribution|lower }} {{ ansible_facts.distribution_release }}/mongodb-org/{{ mongodb_version }} {{ 'multiverse' if ansible_facts.distribution == 'Ubuntu' else 'main' }}"
 redhat:
   rpm_key_key: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Current url cause breaking when installing the repo
![image](https://github.com/user-attachments/assets/fd307aae-6287-419f-991f-ffa74d5fdc6e)

This change set the proper url to retreive key files (https://pgp.mongo.com)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
roles/mongodb_repository/defaults/main.yml
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Running an install will fail because the retrieved apt key is broken.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
