### PR TITLE
Fix import error on Python 3.13

### DIFF
--- a/plugins/module_utils/mongodb_shell.py
+++ b/plugins/module_utils/mongodb_shell.py
@@ -1,16 +1,14 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-# DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
-# Ignore for now
-import warnings
-warnings.filterwarnings("ignore", category=DeprecationWarning)
-
-import shlex
-import pipes
 import re
 import json
 import os
+
+try:
+    from shlex import quote
+except ImportError:
+    from pipes import quote
 
 
 def escape_param(param):
@@ -18,14 +16,7 @@ def escape_param(param):
     Escapes the given parameter
     @param - The parameter to escape
     '''
-    escaped = None
-    if hasattr(shlex, 'quote'):
-        escaped = shlex.quote(param)
-    elif hasattr(pipes, 'quote'):
-        escaped = pipes.quote(param)
-    else:
-        escaped = "'" + param.replace("'", "'\\''") + "'"
-    return escaped
+    return quote(param)
 
 
 def add_arg_to_cmd(cmd_list, param_name, param_value, is_bool=False, omit=None):


### PR DESCRIPTION
##### SUMMARY
Rework `escape_param` to work on Python 3.13.  One of `shlex.quote` or `pipes.quote` exists on all Python versions (back to Python 0.9.8!), so the fallback code for systems that have neither is unnecessary.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils