### PR TITLE
fix: UTF-8 data in the JSON response for ansible 2.18<

### DIFF
--- a/plugins/module_utils/mongodb_common.py
+++ b/plugins/module_utils/mongodb_common.py
@@ -471,12 +471,15 @@ def convert_to_supported(val):
         return str(val)
     # This is for replicasets in the output of general.signature.hash segment
      # This is intended to solve userId output of 
-    elif isinstance(val, bytes) and len(val) == 16:
-       return str(UUID(bytes=val))
-    # Signature hash
-    elif isinstance(val, bytes) and len(val) == 20:
-       return str(base64.b64encode(val).decode('utf-8'))
-
+    elif isinstance(val, bytes):
+        if len(val) == 16:       
+          return str(UUID(bytes=val))
+        elif len(val) == 20:
+          # Signature hash
+          return str(base64.b64encode(val).decode('utf-8'))
+        else:
+          # We dont know what this is but we try to handle it to avoid errors.
+          return val.decode('utf-8'))
     return val  # By default returns the same value
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #692 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
This is done to solve mongodb_info module related

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See #692 
<!--- Paste verbatim command output below, e.g. before and after your change -->
Before output of mongodb_info
```
//When a user is present the userid
\"userId\": \"<E\\udc91\\udc98\\b\\udcacBq\\udcbc\\udcf4|\\udcc8\\udcfd\\r`I\",
// Including the deprecation warning in ansible-core<2.18 and in >2.18 an error "returned non UTF-8 data in the JSON response"

//When the server has a replica set it gives

         "general": {
            "$clusterTime": {
                "clusterTime": "Timestamp(1739390814, 1)",
                "signature": {
                    "hash": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
```

After the fix the signature looks correct.

```
                "signature": {
                    "hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",
```
Equivalent to what mongosh: rs.status()

```
    signature: {
      hash: Binary.createFromBase64('AAAAAAAAAAAAAAAAAAAAAAAAAAA=', 0),
```
 The userid from mongodb_info output look like this:
```
                    "userId": "748a2493-e8c5-46b1-8733-151ca8f11690"
```
As the userid from mongosh show users look like:
``
    userId: UUID('748a2493-e8c5-46b1-8733-151ca8f11690'),

```
And it works with ansible-core 2.18