### PR TITLE
replica_set needs to be empty to leverage localhost exception

### DIFF
--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -26,6 +26,7 @@ options:
   replica_set:
     description:
       - Replica set to connect to (automatically connects to primary for writes).
+      - Leave empty if you need the localhost exception, e.g. to create the initial user
     type: str
   database:
     description:


### PR DESCRIPTION
##### SUMMARY
When `replica_set` is set the connection is created using `directConnection=False`. This prevents using the localhost exception to create the initial user.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
mongodb_user

##### ADDITIONAL INFORMATION

