### PR TITLE
role mongodb_repository: add support of ARM processor architecture for redhat OS family

### DIFF
--- a/roles/mongodb_repository/defaults/main.yml
+++ b/roles/mongodb_repository/defaults/main.yml
@@ -9,7 +9,7 @@ debian:
   apt_repository_repo: "deb{{ ' [ arch=amd64,arm64 ]' if ansible_facts.distribution == 'Ubuntu' else '' }} https://repo.mongodb.org/apt/{{ ansible_facts.distribution|lower }} {{ ansible_facts.distribution_release }}/mongodb-org/{{ mongodb_version }} {{ 'multiverse' if ansible_facts.distribution == 'Ubuntu' else 'main' }}"
 redhat:
   rpm_key_key: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"
-  yum_baseurl: "https://repo.mongodb.org/yum/{{ 'amazon' if ansible_distribution == 'Amazon' else 'redhat'  }}/{{ ansible_facts.distribution_major_version }}/mongodb-org/{{ mongodb_version }}/x86_64/"
+  yum_baseurl: "https://repo.mongodb.org/yum/{{ 'amazon' if ansible_distribution == 'Amazon' else 'redhat'  }}/{{ ansible_facts.distribution_major_version }}/mongodb-org/{{ mongodb_version }}/{{ ansible_architecture }}/"
   yum_gpgkey: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"
   yum_gpgcheck: true
   yum_description: "Official MongoDB {{ mongodb_version }} yum repo"


### PR DESCRIPTION


##### SUMMARY
Add support of aarch64 architecture for redhat/yum installation (already supported for debian family)

use `ansible_architecture` variable instead of string 'x86_64' in yum repo url.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
role mongodb_repository / defaults variables

##### ADDITIONAL INFORMATION
The current workaround is to redefine the `redhat` var, like in the playbook for example:

```yaml
---
- name: Install Mongodb server
  hosts: mongodb
    - role: community.mongodb.mongodb_linux
      become: yes
      tags: [ 'mongodb_linux', 'mongodb' ]
    - role: community.mongodb.mongodb_repository
      become: yes
      tags: [ 'mongodb_repository', 'mongodb' ]
      vars:
        redhat:
          rpm_key_key: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"
          yum_baseurl: "https://repo.mongodb.org/yum/{{ 'amazon' if ansible_distribution == 'Amazon' else 'redhat'  }}/{{ ansible_facts.distribution_major_version }}/mongodb-org/{{ mongodb_version }}/{{ ansible_architecture }}/"
          yum_gpgkey: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"
          yum_gpgcheck: true
          yum_description: "Official MongoDB {{ mongodb_version }} yum repo"
```
