### PR TITLE
mongodb_role: Tests. Add retries to delete tasks

### DIFF
--- a/tests/integration/targets/mongodb_role/tasks/main.yml
+++ b/tests/integration/targets/mongodb_role/tasks/main.yml
@@ -196,8 +196,10 @@
     - 3002
     - 3003
 
-- ansible.builtin.pause:
-    seconds: 5
+# The next delete sales role task was always failing due to replicaset issues
+- name: Allow replicaset time to settle
+  ansible.builtin.pause:
+    seconds: 30
 
 - name: debug
   shell: cat {{ remote_tmp_dir }}/mongod3001/log.log


### PR DESCRIPTION
##### SUMMARY
Add retries to delete tasks. Module integration tests keep failing on these tasks.

##### ISSUE TYPE
- Bugfix Pull Request

