### PR TITLE
Change MongoDB version from 8.0 to 8.2

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -167,7 +167,7 @@ jobs:
         mongodb_version:
           - "6.0"
           - "7.0"
-          #- "8.0". tmp remove MongoDB 8 - Bug? Invalid access at address: 0x20
+          - "8.2" # tmp remove MongoDB 8 - Bug? Invalid access at address: 0x20
           # https://github.com/ansible-collections/community.mongodb/actions/runs/17740301799/job/50412355202?pr=718
         mongodb_module: ${{ fromJson(needs.integration_matrix.outputs.matrix) }}
         versions:


### PR DESCRIPTION
Updated MongoDB version in the test matrix from 8.0 to 8.2.
