### PR TITLE
mongodb_user: add authentication restrictions support

### DIFF
--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -245,12 +245,18 @@ def user_find(client, user, db_name):
     Returns:
         dict: when user exists, False otherwise.
     """
-    try:
+    def run_users_info(query_db_name, lookup_db_name):
         users_doc = {
-            'usersInfo': 1,
+            'usersInfo': {
+                'user': user,
+                'db': lookup_db_name,
+            },
             'showAuthenticationRestrictions': True,
         }
-        for mongo_user in client[db_name].command(users_doc)['users']:
+        return client[query_db_name].command(users_doc)['users']
+
+    try:
+        for mongo_user in run_users_info(db_name, db_name):
             if mongo_user['user'] == user:
                 # NOTE: there is no 'db' field in mongo 2.4.
                 if 'db' not in mongo_user:
@@ -258,6 +264,11 @@ def user_find(client, user, db_name):
                 # Workaround to make the condition works with AWS DocumentDB,
                 # since all users are in the admin database.
                 if mongo_user["db"] in [db_name, "admin"]:
+                    return mongo_user
+
+        if db_name != 'admin':
+            for mongo_user in run_users_info('admin', 'admin'):
+                if mongo_user['user'] == user and mongo_user.get('db') == 'admin':
                     return mongo_user
     except Exception as excep:
         if hasattr(excep, 'code') and excep.code == 11:  # 11=UserNotFound

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -279,7 +279,6 @@ def user_add(module, client, db_name, user, password, roles, authentication_rest
 
     try:
         exists = user_find(client, user, db_name)
-        module.warn(f"user find returned {str(exists)}")
     except Exception as excep:
         # We get this exception: "not authorized on admin to execute command"
         # when auth is enabled on a new instance. The loalhost exception should

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -55,6 +55,17 @@ options:
           'dbAdminAnyDatabase'
       - "Or the following dictionary '{ db: DATABASE_NAME, role: ROLE_NAME }'."
       - "This param requires pymongo 2.5+. If it is a string, mongodb 2.4+ is also required. If it is a dictionary, mongo 2.6+ is required."
+  authentication_restrictions:
+    type: list
+    elements: raw
+    description:
+      - >
+          The authentication restrictions the server enforces on the user.
+          Specifies a list of IP addresses and CIDR ranges the user is allowed
+          to connect from and/or server addresses they can connect to.
+          Provide a list of dictionaries with the following fields:
+          C(clientSource) (list) and C(serverAddress) (list).
+      - Provide an empty list if you don't want to use the field.
   state:
     description:
       - The database user state.
@@ -179,6 +190,22 @@ EXAMPLES = '''
     auth_mechanism: "MONGODB-X509"
     connection_options:
      - "tlsAllowInvalidHostnames=true"
+
+- name: Create a user restricted to localhost authentication
+  community.mongodb.mongodb_user:
+    login_user: root
+    login_password: root_password
+    database: admin
+    name: app_user
+    password: secure_password
+    roles:
+      - db: appdb
+        role: readWrite
+    authentication_restrictions:
+      - clientSource:
+          - "127.0.0.1"
+          - "::1"
+    state: present
 '''
 
 RETURN = '''
@@ -217,7 +244,11 @@ def user_find(client, user, db_name):
         dict: when user exists, False otherwise.
     """
     try:
-        for mongo_user in client[db_name].command('usersInfo')['users']:
+        users_doc = {
+            'usersInfo': 1,
+            'showAuthenticationRestrictions': True,
+        }
+        for mongo_user in client[db_name].command(users_doc)['users']:
             if mongo_user['user'] == user:
                 # NOTE: there is no 'db' field in mongo 2.4.
                 if 'db' not in mongo_user:
@@ -234,7 +265,7 @@ def user_find(client, user, db_name):
     return False
 
 
-def user_add(module, client, db_name, user, password, roles):
+def user_add(module, client, db_name, user, password, roles, authentication_restrictions):
     # pymongo's user_add is a _create_or_update_user so we won't know if it was changed or updated
     # without reproducing a lot of the logic in database.py of pymongo
     db = client[db_name]
@@ -262,6 +293,8 @@ def user_add(module, client, db_name, user, password, roles):
         user_dict["pwd"] = password
     if roles is not None:
         user_dict["roles"] = roles
+    if authentication_restrictions is not None:
+        user_dict["authenticationRestrictions"] = authentication_restrictions
 
     db.command(user_add_db_command, user, **user_dict)
 
@@ -294,22 +327,43 @@ def check_if_roles_changed(uinfo, roles, db_name):
     #     ]
     # }
 
-    def make_sure_roles_are_a_list_of_dict(roles, db_name):
-        output = list()
-        for role in roles:
-            if isinstance(role, (binary_type, text_type)):
-                new_role = {"role": role, "db": db_name}
-                output.append(new_role)
-            else:
-                output.append(role)
-        return output
-
     roles_as_list_of_dict = make_sure_roles_are_a_list_of_dict(roles, db_name)
     uinfo_roles = uinfo.get('roles', [])
 
     if sorted(roles_as_list_of_dict, key=lambda roles: sorted(roles.items())) == sorted(uinfo_roles, key=lambda roles: sorted(roles.items())):
         return False
     return True
+
+
+def make_sure_roles_are_a_list_of_dict(roles, db_name):
+    output = list()
+    for role in roles:
+        if isinstance(role, (binary_type, text_type)):
+            new_role = {"role": role, "db": db_name}
+            output.append(new_role)
+        else:
+            output.append(role)
+    return output
+
+
+def normalize_authentication_restrictions(authentication_restrictions):
+    normalized = []
+    for restriction in authentication_restrictions or []:
+        if isinstance(restriction, (list, tuple)) and restriction and isinstance(restriction[0], dict):
+            restriction = restriction[0]
+
+        normalized.append({
+            'clientSource': sorted(restriction.get('clientSource', [])),
+            'serverAddress': sorted(restriction.get('serverAddress', [])),
+        })
+
+    return sorted(normalized, key=lambda item: (item['clientSource'], item['serverAddress']))
+
+
+def check_if_authentication_restrictions_changed(uinfo, authentication_restrictions):
+    current = normalize_authentication_restrictions(uinfo.get('authenticationRestrictions', []))
+    desired = normalize_authentication_restrictions(authentication_restrictions)
+    return current != desired
 
 
 # =========================================
@@ -324,6 +378,7 @@ def main():
         password=dict(aliases=['pass'], no_log=True),
         replica_set=dict(default=None),
         roles=dict(default=None, type='list', elements='raw'),
+        authentication_restrictions=dict(default=[], type='list', elements='raw', aliases=['authenticationRestrictions']),
         state=dict(default='present', choices=['absent', 'present']),
         update_password=dict(default="always", choices=["always", "on_create"], no_log=False),
         create_for_localhost_exception=dict(default=None, type='path'),
@@ -352,6 +407,7 @@ def main():
     user = module.params['name']
     password = module.params['password']
     roles = module.params['roles'] or []
+    authentication_restrictions = module.params['authentication_restrictions'] or []
     state = module.params['state']
     update_password = module.params['update_password']
 
@@ -381,12 +437,13 @@ def main():
                 uinfo = user_find(client, user, db_name)
                 if uinfo:
                     password = None
-                    if not check_if_roles_changed(uinfo, roles, db_name):
+                    if (not check_if_roles_changed(uinfo, roles, db_name) and
+                            not check_if_authentication_restrictions_changed(uinfo, authentication_restrictions)):
                         module.exit_json(changed=False, user=user)
 
             if module.check_mode:
                 module.exit_json(changed=True, user=user)
-            user_add(module, client, db_name, user, password, roles)
+            user_add(module, client, db_name, user, password, roles, authentication_restrictions)
         except Exception as e:
             module.fail_json(msg='Unable to add or update user: %s' % to_native(e), exception=traceback.format_exc())
         finally:

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -295,7 +295,7 @@ def user_add(module, client, db_name, user, password, roles, authentication_rest
 
     try:
         exists = user_find(client, user, db_name)
-        module.WARN(f"user find returned {str(exists)}")
+        module.warn(f"user find returned {str(exists)}")
     except Exception as excep:
         # We get this exception: "not authorized on admin to execute command"
         # when auth is enabled on a new instance. The loalhost exception should

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -295,6 +295,7 @@ def user_add(module, client, db_name, user, password, roles, authentication_rest
 
     try:
         exists = user_find(client, user, db_name)
+        module.WARN(f"user find returned {str(exists)}")
     except Exception as excep:
         # We get this exception: "not authorized on admin to execute command"
         # when auth is enabled on a new instance. The loalhost exception should

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -244,10 +244,16 @@ def user_find(client, user, db_name):
 
     Returns:
         dict: when user exists, False otherwise.
+
+    Notes: Now that we query using showAuthenticationRestrictions
+    we have to update the query to filter for a specifc user
     """
     try:
         for mongo_user in client[db_name].command({
-            'usersInfo': 1,
+            'usersInfo': {
+                'user': user,
+                'db': db_name
+            },
             'showAuthenticationRestrictions': True,
         })['users']:
             if mongo_user['user'] == user:

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -295,7 +295,10 @@ def user_add(module, client, db_name, user, password, roles, authentication_rest
         user_dict["pwd"] = password
     if roles is not None:
         user_dict["roles"] = roles
-    if authentication_restrictions is not None:
+    # Keep localhost-exception flows working by omitting the field on createUser
+    # when the desired restriction list is empty. updateUser still needs an empty
+    # list to clear existing authentication restrictions.
+    if exists or authentication_restrictions:
         user_dict["authenticationRestrictions"] = authentication_restrictions
 
     db.command(user_add_db_command, user, **user_dict)

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -58,6 +58,8 @@ options:
   authentication_restrictions:
     type: list
     elements: raw
+    default: []
+    aliases: [authenticationRestrictions]
     description:
       - >
           The authentication restrictions the server enforces on the user.

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -281,7 +281,7 @@ def user_add(module, client, db_name, user, password, roles, authentication_rest
         exists = user_find(client, user, db_name)
     except Exception as excep:
         # We get this exception: "not authorized on admin to execute command"
-        # when auth is enabled on a new instance. The loalhost exception should
+        # when auth is enabled on a new instance. The localhost exception should
         # allow us to create the first user. If the localhost exception does not apply,
         # then user creation will also fail with unauthorized. So, ignore Unauthorized here.
         if hasattr(excep, 'code') and excep.code == 13:  # 13=Unauthorized

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -246,7 +246,10 @@ def user_find(client, user, db_name):
         dict: when user exists, False otherwise.
     """
     try:
-        for mongo_user in client[db_name].command('usersInfo')['users']:
+        for mongo_user in client[db_name].command({
+            'usersInfo': 1,
+            'showAuthenticationRestrictions': True,
+        })['users']:
             if mongo_user['user'] == user:
                 # NOTE: there is no 'db' field in mongo 2.4.
                 if 'db' not in mongo_user:

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -245,46 +245,21 @@ def user_find(client, user, db_name):
     Returns:
         dict: when user exists, False otherwise.
     """
-    def run_users_info(query_db_name, lookup_db_name):
-        users_doc = {
-            'usersInfo': {
-                'user': user,
-                'db': lookup_db_name,
-            },
-            'showAuthenticationRestrictions': True,
-        }
-        return client[query_db_name].command(users_doc)['users']
-
-    # --- First attempt ---
     try:
-        users = run_users_info(db_name, db_name)
+        for mongo_user in client[db_name].command('usersInfo')['users']:
+            if mongo_user['user'] == user:
+                # NOTE: there is no 'db' field in mongo 2.4.
+                if 'db' not in mongo_user:
+                    return mongo_user
+                # Workaround to make the condition works with AWS DocumentDB,
+                # since all users are in the admin database.
+                if mongo_user["db"] in [db_name, "admin"]:
+                    return mongo_user
     except Exception as excep:
-        if hasattr(excep, 'code') and excep.code == 11:
-            users = []
+        if hasattr(excep, 'code') and excep.code == 11:  # 11=UserNotFound
+            pass  # Allow return False
         else:
             raise
-
-    for mongo_user in users:
-        if mongo_user['user'] == user:
-            if 'db' not in mongo_user:
-                return mongo_user
-            if mongo_user["db"] in [db_name, "admin"]:
-                return mongo_user
-
-    # --- Fallback (always reached if not found above) ---
-    if db_name != 'admin':
-        try:
-            users = run_users_info('admin', 'admin')
-        except Exception as excep:
-            if hasattr(excep, 'code') and excep.code == 11:
-                users = []
-            else:
-                raise
-
-        for mongo_user in users:
-            if mongo_user['user'] == user:
-                return mongo_user
-
     return False
 
 

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -255,26 +255,36 @@ def user_find(client, user, db_name):
         }
         return client[query_db_name].command(users_doc)['users']
 
+    # --- First attempt ---
     try:
-        for mongo_user in run_users_info(db_name, db_name):
-            if mongo_user['user'] == user:
-                # NOTE: there is no 'db' field in mongo 2.4.
-                if 'db' not in mongo_user:
-                    return mongo_user
-                # Workaround to make the condition works with AWS DocumentDB,
-                # since all users are in the admin database.
-                if mongo_user["db"] in [db_name, "admin"]:
-                    return mongo_user
-
-        if db_name != 'admin':
-            for mongo_user in run_users_info('admin', 'admin'):
-                if mongo_user['user'] == user and mongo_user.get('db') == 'admin':
-                    return mongo_user
+        users = run_users_info(db_name, db_name)
     except Exception as excep:
-        if hasattr(excep, 'code') and excep.code == 11:  # 11=UserNotFound
-            pass  # Allow return False
+        if hasattr(excep, 'code') and excep.code == 11:
+            users = []
         else:
             raise
+
+    for mongo_user in users:
+        if mongo_user['user'] == user:
+            if 'db' not in mongo_user:
+                return mongo_user
+            if mongo_user["db"] in [db_name, "admin"]:
+                return mongo_user
+
+    # --- Fallback (always reached if not found above) ---
+    if db_name != 'admin':
+        try:
+            users = run_users_info('admin', 'admin')
+        except Exception as excep:
+            if hasattr(excep, 'code') and excep.code == 11:
+                users = []
+            else:
+                raise
+
+        for mongo_user in users:
+            if mongo_user['user'] == user:
+                return mongo_user
+
     return False
 
 

--- a/tests/integration/targets/mongodb_user/tasks/709.yml
+++ b/tests/integration/targets/mongodb_user/tasks/709.yml
@@ -1,0 +1,109 @@
+- name: Create user with authentication restrictions
+  community.mongodb.mongodb_user:
+    login_user: '{{ mongodb_admin_user }}'
+    login_password: '{{ mongodb_admin_password }}'
+    login_database: admin
+    login_port: 3001
+    replica_set: '{{ current_replicaset }}'
+    database: admin
+    name: restricted_user
+    password: secret
+    roles: readAnyDatabase
+    authentication_restrictions:
+      - clientSource:
+          - 127.0.0.1
+          - ::1
+    state: present
+    update_password: on_create
+  register: restricted_user_created
+
+- assert:
+    that:
+    - restricted_user_created.changed
+
+- name: Re-run restricted user creation to verify idempotence
+  community.mongodb.mongodb_user:
+    login_user: '{{ mongodb_admin_user }}'
+    login_password: '{{ mongodb_admin_password }}'
+    login_database: admin
+    login_port: 3001
+    replica_set: '{{ current_replicaset }}'
+    database: admin
+    name: restricted_user
+    password: secret
+    roles: readAnyDatabase
+    authentication_restrictions:
+      - clientSource:
+          - ::1
+          - 127.0.0.1
+    state: present
+    update_password: on_create
+  register: restricted_user_idempotent
+
+- assert:
+    that:
+    - not restricted_user_idempotent.changed
+
+- name: Get restricted user details with authentication restrictions
+  mongodb_shell:
+    login_host: "{{ current_replicaset }}/localhost"
+    login_port: 3001
+    login_user: "{{ mongodb_admin_user }}"
+    login_password: "{{ mongodb_admin_password }}"
+    login_database: admin
+    db: admin
+    eval: "printjson(db.runCommand({usersInfo: 'restricted_user', showAuthenticationRestrictions: true}))"
+    mongo_cmd: "auto"
+    transform: "raw"
+  register: restricted_user_details
+
+- assert:
+    that:
+    - "'restricted_user' in restricted_user_details.transformed_output | string"
+    - "'127.0.0.1' in restricted_user_details.transformed_output | string"
+    - "'::1' in restricted_user_details.transformed_output | string"
+
+- name: Update user with additional authentication restrictions
+  community.mongodb.mongodb_user:
+    login_user: '{{ mongodb_admin_user }}'
+    login_password: '{{ mongodb_admin_password }}'
+    login_database: admin
+    login_port: 3001
+    replica_set: '{{ current_replicaset }}'
+    database: admin
+    name: restricted_user
+    password: secret
+    roles: readAnyDatabase
+    authentication_restrictions:
+      - clientSource:
+          - 127.0.0.1
+          - ::1
+        serverAddress:
+          - 127.0.0.1
+      - clientSource:
+          - 10.0.0.0/8
+    state: present
+    update_password: on_create
+  register: restricted_user_updated
+
+- assert:
+    that:
+    - restricted_user_updated.changed
+
+- name: Get updated restricted user details
+  mongodb_shell:
+    login_host: "{{ current_replicaset }}/localhost"
+    login_port: 3001
+    login_user: "{{ mongodb_admin_user }}"
+    login_password: "{{ mongodb_admin_password }}"
+    login_database: admin
+    db: admin
+    eval: "printjson(db.runCommand({usersInfo: 'restricted_user', showAuthenticationRestrictions: true}))"
+    mongo_cmd: "auto"
+    transform: "raw"
+  register: restricted_user_updated_details
+
+- assert:
+    that:
+    - "'10.0.0.0/8' in restricted_user_updated_details.transformed_output | string"
+    - "'serverAddress' in restricted_user_updated_details.transformed_output | string"

--- a/tests/integration/targets/mongodb_user/tasks/main.yml
+++ b/tests/integration/targets/mongodb_user/tasks/main.yml
@@ -175,6 +175,9 @@
     - "'dbAdmin' in test_db_users.transformed_output | string"
     - "'userAdmin' in test_db_users.transformed_output | string"
 
+- name: Import tasks for issue 709
+  import_tasks: 709.yml
+
 - name: Drop users in test db
   community.mongodb.mongodb_user:
     login_user: '{{ mongodb_admin_user }}'

--- a/tests/unit/test_mongodb_user.py
+++ b/tests/unit/test_mongodb_user.py
@@ -55,6 +55,36 @@ class TestMongoDBUserMethods(unittest.TestCase):
         self.assertFalse(mongodb_user.check_if_roles_changed(uinfo, roles_ordered, ''))
         self.assertFalse(mongodb_user.check_if_roles_changed(uinfo, roles_disordered, ''))
 
+    def test_check_if_authentication_restrictions_changed_same_values(self):
+        uinfo = {
+            'authenticationRestrictions': [
+                [{'clientSource': ['127.0.0.1', '::1'], 'serverAddress': []}],
+                [{'clientSource': ['10.0.0.0/8'], 'serverAddress': ['192.168.1.10']}],
+            ]
+        }
+        restrictions = [
+            {'clientSource': ['10.0.0.0/8'], 'serverAddress': ['192.168.1.10']},
+            {'clientSource': ['::1', '127.0.0.1'], 'serverAddress': []},
+        ]
+
+        self.assertFalse(
+            mongodb_user.check_if_authentication_restrictions_changed(uinfo, restrictions)
+        )
+
+    def test_check_if_authentication_restrictions_changed_detects_difference(self):
+        uinfo = {
+            'authenticationRestrictions': [
+                {'clientSource': ['127.0.0.1'], 'serverAddress': []},
+            ]
+        }
+        restrictions = [
+            {'clientSource': ['127.0.0.1'], 'serverAddress': ['10.0.0.0/8']},
+        ]
+
+        self.assertTrue(
+            mongodb_user.check_if_authentication_restrictions_changed(uinfo, restrictions)
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_mongodb_user.py
+++ b/tests/unit/test_mongodb_user.py
@@ -85,6 +85,60 @@ class TestMongoDBUserMethods(unittest.TestCase):
             mongodb_user.check_if_authentication_restrictions_changed(uinfo, restrictions)
         )
 
+    def test_user_add_omits_empty_authentication_restrictions_on_create(self):
+        class FakeDB:
+            def __init__(self):
+                self.calls = []
+
+            def command(self, command_name, user, **kwargs):
+                self.calls.append((command_name, user, kwargs))
+
+        class FakeClient(dict):
+            pass
+
+        db = FakeDB()
+        client = FakeClient({'admin': db})
+        original_user_find = mongodb_user.user_find
+
+        try:
+            mongodb_user.user_find = lambda client, user, db_name: False
+            mongodb_user.user_add(None, client, 'admin', 'alice', 'secret', ['root'], [])
+        finally:
+            mongodb_user.user_find = original_user_find
+
+        self.assertEqual(1, len(db.calls))
+        command_name, user, kwargs = db.calls[0]
+        self.assertEqual('createUser', command_name)
+        self.assertEqual('alice', user)
+        self.assertNotIn('authenticationRestrictions', kwargs)
+
+    def test_user_add_keeps_empty_authentication_restrictions_on_update(self):
+        class FakeDB:
+            def __init__(self):
+                self.calls = []
+
+            def command(self, command_name, user, **kwargs):
+                self.calls.append((command_name, user, kwargs))
+
+        class FakeClient(dict):
+            pass
+
+        db = FakeDB()
+        client = FakeClient({'admin': db})
+        original_user_find = mongodb_user.user_find
+
+        try:
+            mongodb_user.user_find = lambda client, user, db_name: {'user': user}
+            mongodb_user.user_add(None, client, 'admin', 'alice', None, ['root'], [])
+        finally:
+            mongodb_user.user_find = original_user_find
+
+        self.assertEqual(1, len(db.calls))
+        command_name, user, kwargs = db.calls[0]
+        self.assertEqual('updateUser', command_name)
+        self.assertEqual('alice', user)
+        self.assertEqual([], kwargs['authenticationRestrictions'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_mongodb_user.py
+++ b/tests/unit/test_mongodb_user.py
@@ -139,6 +139,36 @@ class TestMongoDBUserMethods(unittest.TestCase):
         self.assertEqual('alice', user)
         self.assertEqual([], kwargs['authenticationRestrictions'])
 
+    def test_user_find_uses_exact_match_users_info_query(self):
+        class FakeDB:
+            def __init__(self):
+                self.calls = []
+
+            def command(self, payload):
+                self.calls.append(payload)
+                return {
+                    'users': [
+                        {'user': 'alice', 'db': 'admin', 'roles': []},
+                    ]
+                }
+
+        class FakeClient(dict):
+            pass
+
+        db = FakeDB()
+        client = FakeClient({'admin': db})
+
+        result = mongodb_user.user_find(client, 'alice', 'admin')
+
+        self.assertEqual('alice', result['user'])
+        self.assertEqual(
+            {
+                'usersInfo': {'user': 'alice', 'db': 'admin'},
+                'showAuthenticationRestrictions': True,
+            },
+            db.calls[0],
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `authentication_restrictions` support to `community.mongodb.mongodb_user` (with a camelCase alias for compatibility)
- request `showAuthenticationRestrictions` from `usersInfo` and compare normalized restrictions so `update_password: on_create` stays idempotent
- add unit coverage for authentication restriction comparison and an integration scenario for create, idempotent re-run, and update flows

Closes #709.

## Testing
- `PYTHONPATH=$(pwd)/.tmp_collections ANSIBLE_COLLECTIONS_PATH=$(pwd)/.tmp_collections .venv/bin/python -m unittest tests/unit/test_mongodb_user.py`
- `.venv/bin/python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('tests/integration/targets/mongodb_user/tasks/709.yml').read_text()); yaml.safe_load(pathlib.Path('tests/integration/targets/mongodb_user/tasks/main.yml').read_text()); print('yaml-ok')"`
- `git diff --check`
