### PR TITLE
Fix for LDAP $external database

### DIFF
--- a/plugins/module_utils/mongodb_atlas.py
+++ b/plugins/module_utils/mongodb_atlas.py
@@ -75,7 +75,7 @@ class AtlasAPIObject:
     def exists(self):
         additional_path = ""
         if self.path == "/databaseUsers":
-            additional_path = "/" + self.data.get("databaseName", "admin")
+            additional_path = "/" +self.module.params["database_name"]
         ret = self.call_url(
             path=self.path
             + additional_path

--- a/plugins/module_utils/mongodb_atlas.py
+++ b/plugins/module_utils/mongodb_atlas.py
@@ -75,7 +75,7 @@ class AtlasAPIObject:
     def exists(self):
         additional_path = ""
         if self.path == "/databaseUsers":
-            additional_path = "/admin"
+            additional_path = "/" + self.data.get("databaseName", "admin")
         ret = self.call_url(
             path=self.path
             + additional_path
@@ -97,7 +97,7 @@ class AtlasAPIObject:
     def delete(self):
         additional_path = ""
         if self.path == "/databaseUsers":
-            additional_path = "/admin"
+            additional_path = "/" + self.data.get("databaseName", "admin")
         ret = self.call_url(
             path=self.path
             + additional_path
@@ -110,7 +110,7 @@ class AtlasAPIObject:
     def modify(self):
         additional_path = ""
         if self.path == "/databaseUsers":
-            additional_path = "/admin"
+            additional_path = "/" + self.data.get("databaseName", "admin")
         ret = self.call_url(
             path=self.path
             + additional_path
@@ -124,7 +124,7 @@ class AtlasAPIObject:
     def diff(self):
         additional_path = ""
         if self.path == "/databaseUsers":
-            additional_path = "/admin"
+            additional_path = "/" + self.data.get("databaseName", "admin")
         ret = self.call_url(
             path=self.path
             + additional_path

--- a/plugins/module_utils/mongodb_atlas.py
+++ b/plugins/module_utils/mongodb_atlas.py
@@ -75,7 +75,7 @@ class AtlasAPIObject:
     def exists(self):
         additional_path = ""
         if self.path == "/databaseUsers":
-            additional_path = "/" +self.module.params["database_name"]
+            additional_path = "/" + self.module.params["database_name"]
         ret = self.call_url(
             path=self.path
             + additional_path
@@ -97,7 +97,7 @@ class AtlasAPIObject:
     def delete(self):
         additional_path = ""
         if self.path == "/databaseUsers":
-            additional_path = "/" + self.data.get("databaseName", "admin")
+            additional_path = "/" + self.module.params["database_name"]
         ret = self.call_url(
             path=self.path
             + additional_path
@@ -110,7 +110,7 @@ class AtlasAPIObject:
     def modify(self):
         additional_path = ""
         if self.path == "/databaseUsers":
-            additional_path = "/" + self.data.get("databaseName", "admin")
+            additional_path = "/" + self.module.params["database_name"]
         ret = self.call_url(
             path=self.path
             + additional_path
@@ -124,7 +124,7 @@ class AtlasAPIObject:
     def diff(self):
         additional_path = ""
         if self.path == "/databaseUsers":
-            additional_path = "/" + self.data.get("databaseName", "admin")
+            additional_path = "/" + self.module.params["database_name"]
         ret = self.call_url(
             path=self.path
             + additional_path


### PR DESCRIPTION
##### SUMMARY
Fix for wrong detection of LDAP users. We need to check in $external database and 'admin' db was hardcoded.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.mongodb.mongodb_atlas_ldap_user

##### ADDITIONAL INFORMATION
Without proposed change rerun of Ansible shows error on created users. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
before:
failed: [localhost] (item={'name': 'CN=Dummy User,OU=User Accounts,DC=corp,DC=corp,DC=com', 'state': 'present', 'roles': [{'role': 'myrole', 'db': 'admin'}], 'database': '$external', 'ldap_auth_type': 'USER'}) => {"ansible_loop_var": "item", "changed": false, "item": {"database": "$external", "ldap_auth_type": "USER", "name": "CN=Dummy User,OU=User Accounts,DC=corp,DC=corp,DC=com", "roles": [{"db": "admin", "role": "myrtle"}], "state": "present"}, "msg": "exception while creating: Expecting value: line 1 column 1 (char 0)"}

after:
ok: [localhost] => (item={'name': 'CN=Dummy User,OU=User Accounts,DC=corp,DC=corp,DC=com', 'state': 'present', 'roles': [{'role': 'myrole', 'db': 'admin'}], 'ldap_auth_type': 'USER'})
```
