### PR TITLE
MongoDB Atlas - add user invitation, federation role mapping (console access) and OIDC user (data access)

### DIFF
--- a/plugins/module_utils/mongodb_atlas.py
+++ b/plugins/module_utils/mongodb_atlas.py
@@ -17,6 +17,31 @@ except ImportError:
         quote,
     )  # pylint: disable=locally-disabled, import-error, no-name-in-module
 
+ATLAS_API_V2_VERSION = "2025-02-19"
+
+
+def get_bearer_token(module, service_account_id, service_account_secret):
+    """Obtain OAuth2 Bearer token using client_credentials grant."""
+    import base64
+    credentials = base64.b64encode(
+        "{0}:{1}".format(service_account_id, service_account_secret).encode("utf-8")
+    ).decode("utf-8")
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Accept": "application/json",
+        "Authorization": "Basic {0}".format(credentials),
+    }
+    rsp, info = fetch_url(
+        module=module,
+        url="https://cloud.mongodb.com/api/oauth/token",
+        data="grant_type=client_credentials",
+        headers=headers,
+        method="POST",
+    )
+    if info["status"] != 200:
+        module.fail_json(msg="Failed to obtain Atlas Bearer token. HTTP %d" % info["status"])
+    return json.loads(rsp.read())["access_token"]
+
 
 class AtlasAPIObject:
     module = None
@@ -218,3 +243,89 @@ class AtlasAPIObject:
                             msg="exception while creating: " + str(e)
                         )
         return changed, diff_result
+
+
+class AtlasAPIObjectV2(AtlasAPIObject):
+    """Atlas API v2 variant supporting both OAuth2 Bearer (Service Account)
+    and Digest authentication (API public/private key).
+
+    Authentication priority:
+      - If service_account_id and service_account_secret are provided: OAuth2 Bearer
+      - If api_username and api_password are provided: Digest (same as AtlasAPIObject)
+
+    Additional arguments vs AtlasAPIObject:
+      - base_url             : full URL prefix replacing /api/atlas/v1.0/groups/{group_id}
+      - service_account_id   : OAuth2 client ID (optional)
+      - service_account_secret: OAuth2 client secret (optional)
+    """
+
+    def __init__(
+        self,
+        module,
+        object_name,
+        path,
+        data,
+        base_url,
+        group_id="",
+        data_is_array=False,
+        service_account_id=None,
+        service_account_secret=None,
+        api_username=None,
+        api_password=None,
+    ):
+        self.module = module
+        self.path = path
+        self.data = data
+        self.group_id = group_id
+        self.object_name = object_name
+        self.data_is_array = data_is_array
+        self._base_url = base_url
+
+        if service_account_id and service_account_secret:
+            self._auth_type = "bearer"
+            self._bearer_token = get_bearer_token(module, service_account_id, service_account_secret)
+        elif api_username and api_password:
+            self._auth_type = "digest"
+            self.module.params["url_username"] = api_username
+            self.module.params["url_password"] = api_password
+        else:
+            module.fail_json(
+                msg="Either service_account_id/service_account_secret or api_username/api_password must be provided."
+            )
+
+    def call_url(self, path, data="", method="GET"):
+        headers = {
+            "Accept": "application/vnd.atlas.{0}+json".format(ATLAS_API_V2_VERSION),
+            "Content-Type": "application/vnd.atlas.{0}+json".format(ATLAS_API_V2_VERSION),
+        }
+
+        if self._auth_type == "bearer":
+            headers["Authorization"] = "Bearer {0}".format(self._bearer_token)
+
+        if self.data_is_array and data != "":
+            data = "[" + data + "]"
+
+        url = self._base_url + path
+        rsp, info = fetch_url(
+            module=self.module,
+            url=url,
+            data=data,
+            headers=headers,
+            method=method,
+        )
+
+        content = ""
+        error = ""
+        if rsp and info["status"] not in (204, 404):
+            content = json.loads(rsp.read())
+        if info["status"] >= 400:
+            try:
+                content = json.loads(info["body"])
+                error = content.get("reason", "Unknown error")
+                if "detail" in content:
+                    error += ". Detail: " + content["detail"]
+            except ValueError:
+                error = info["msg"]
+        if info["status"] < 0:
+            error = info["msg"]
+        return {"code": info["status"], "data": content, "error": error}

--- a/plugins/modules/mongodb_atlas_federation_role_mapping.py
+++ b/plugins/modules/mongodb_atlas_federation_role_mapping.py
@@ -28,7 +28,6 @@ options:
     description:
       - MongoDB Atlas Service Account client secret (OAuth2).
       - Mutually exclusive with C(api_password).
-    no_log: true
     type: str
     aliases: [ "serviceAccountSecret" ]
   api_username:
@@ -39,7 +38,6 @@ options:
   api_password:
     description:
       - Atlas API private key. Alternative to C(service_account_secret).
-    no_log: true
     type: str
     aliases: [ "apiPassword" ]
   federation_settings_id:

--- a/plugins/modules/mongodb_atlas_federation_role_mapping.py
+++ b/plugins/modules/mongodb_atlas_federation_role_mapping.py
@@ -1,0 +1,280 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: mongodb_atlas_federation_role_mapping
+short_description: Manage Atlas Federation role mappings for SAML/OIDC groups
+description:
+  - Manage role mappings between external IdP groups and MongoDB Atlas org/project roles.
+  - Used to grant Atlas Console access to SAML/SSO groups (e.g. ORG_OWNER, GROUP_READ_ONLY).
+  - Uses OAuth2 client_credentials (Service Account) for authentication.
+  - L(API Documentation,https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Federated-Authentication)
+author: "Karol Murawski (@kazz3m)"
+options:
+  service_account_id:
+    description:
+      - MongoDB Atlas Service Account client ID (OAuth2).
+      - Mutually exclusive with C(api_username).
+    type: str
+    aliases: [ "serviceAccountId" ]
+  service_account_secret:
+    description:
+      - MongoDB Atlas Service Account client secret (OAuth2).
+      - Mutually exclusive with C(api_password).
+    no_log: true
+    type: str
+    aliases: [ "serviceAccountSecret" ]
+  api_username:
+    description:
+      - Atlas API public key. Alternative to C(service_account_id).
+    type: str
+    aliases: [ "apiUsername" ]
+  api_password:
+    description:
+      - Atlas API private key. Alternative to C(service_account_secret).
+    no_log: true
+    type: str
+    aliases: [ "apiPassword" ]
+  federation_settings_id:
+    description:
+      - Unique identifier of the federation settings.
+    required: true
+    type: str
+    aliases: [ "federationSettingsId" ]
+  org_id:
+    description:
+      - Unique identifier of the Atlas organization.
+    required: true
+    type: str
+    aliases: [ "orgId" ]
+  state:
+    description:
+      - Desired state of the role mapping.
+    choices: [ "present", "absent" ]
+    default: present
+    type: str
+  external_group_name:
+    description:
+      - Name of the external IdP group (e.g. AD/SAML group name).
+    required: true
+    type: str
+    aliases: [ "externalGroupName" ]
+  role_assignments:
+    description:
+      - List of Atlas role assignments for this group.
+    required: true
+    type: list
+    elements: dict
+    suboptions:
+      org_id:
+        description:
+          - Atlas org ID for org-level role assignment. Mutually exclusive with group_id.
+        type: str
+        aliases: [ "orgId" ]
+      group_id:
+        description:
+          - Atlas project ID for project-level role assignment. Mutually exclusive with org_id.
+        type: str
+        aliases: [ "groupId" ]
+      role:
+        description:
+          - Atlas role name (e.g. ORG_OWNER, ORG_MEMBER, GROUP_READ_ONLY).
+        required: true
+        type: str
+'''
+
+EXAMPLES = '''
+- name: Map AD group to ORG_OWNER in Atlas
+  community.mongodb.mongodb_atlas_federation_role_mapping:
+    service_account_id: "mdb_sa_id_xxxx"
+    service_account_secret: "mdb_sa_sk_xxxx"
+    federation_settings_id: "69d3f63fd91aa77b74a930a0"
+    org_id: "694ec9ddbaecce170ffe8b62"
+    external_group_name: "SG-OCI-INFRA-ADMINS"
+    role_assignments:
+      - org_id: "694ec9ddbaecce170ffe8b62"
+        role: "ORG_OWNER"
+
+- name: Map AD group to project read-only
+  community.mongodb.mongodb_atlas_federation_role_mapping:
+    service_account_id: "mdb_sa_id_xxxx"
+    service_account_secret: "mdb_sa_sk_xxxx"
+    federation_settings_id: "69d3f63fd91aa77b74a930a0"
+    org_id: "694ec9ddbaecce170ffe8b62"
+    external_group_name: "SG-OCI-DB-Family"
+    role_assignments:
+      - org_id: "694ec9ddbaecce170ffe8b62"
+        role: "ORG_MEMBER"
+      - group_id: "6991db0a32bf1b56dbb63d62"
+        role: "GROUP_READ_ONLY"
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.mongodb.plugins.module_utils.mongodb_atlas import (
+    AtlasAPIObjectV2,
+)
+
+
+def main():
+    argument_spec = dict(
+        state=dict(default="present", choices=["absent", "present"]),
+        service_account_id=dict(aliases=["serviceAccountId"]),
+        service_account_secret=dict(no_log=True, aliases=["serviceAccountSecret"]),
+        api_username=dict(aliases=["apiUsername"]),
+        api_password=dict(no_log=True, aliases=["apiPassword"]),
+        federation_settings_id=dict(required=True, aliases=["federationSettingsId"]),
+        org_id=dict(required=True, aliases=["orgId"]),
+        external_group_name=dict(required=True, aliases=["externalGroupName"]),
+        role_assignments=dict(
+            required=True,
+            type="list",
+            elements="dict",
+            options=dict(
+                org_id=dict(type="str", default=None, aliases=["orgId"]),
+                group_id=dict(type="str", default=None, aliases=["groupId"]),
+                role=dict(required=True, type="str"),
+            ),
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec, supports_check_mode=True
+    )
+
+    role_assignments = []
+    for ra in module.params.get("role_assignments"):
+        role_assignments.append({
+            "orgId": ra.get("org_id"),
+            "groupId": ra.get("group_id"),
+            "role": ra.get("role"),
+        })
+
+    data = {
+        "externalGroupName": module.params["external_group_name"],
+        "roleAssignments": role_assignments,
+    }
+
+    base_url = (
+        "https://cloud.mongodb.com/api/atlas/v2/federationSettings/"
+        + module.params["federation_settings_id"]
+        + "/connectedOrgConfigs/"
+        + module.params["org_id"]
+    )
+
+    # Build AtlasAPIObjectV2 only to get a working call_url() with correct auth/headers.
+    # We cannot use atlas.update() here because the /roleMappings endpoint:
+    #   - has no GET-by-name (requires listing and matching by externalGroupName)
+    #   - returns HTTP 200 (not 201) on POST
+    #   - requires PUT /{id} (not PATCH /{name}) for updates
+    try:
+        atlas = AtlasAPIObjectV2(
+            module=module,
+            path="/roleMappings",
+            object_name="externalGroupName",
+            data=data,
+            base_url=base_url,
+            service_account_id=module.params.get("service_account_id"),
+            service_account_secret=module.params.get("service_account_secret"),
+            api_username=module.params.get("api_username"),
+            api_password=module.params.get("api_password"),
+        )
+    except Exception as e:
+        module.fail_json(
+            msg="unable to connect to Atlas API. Exception message: %s" % e
+        )
+
+    # Find existing mapping by externalGroupName
+    existing_id = None
+    existing_data = None
+    ret = atlas.call_url(path="/roleMappings")
+    if ret["code"] == 200:
+        for item in ret["data"].get("results", []):
+            if item.get("externalGroupName") == data["externalGroupName"]:
+                existing_id = item["id"]
+                existing_data = item
+                break
+    elif ret["code"] not in (404,):
+        module.fail_json(
+            msg="failed to list role mappings: %d. Error: %s" % (ret["code"], ret["error"])
+        )
+
+    state = module.params["state"]
+    changed = False
+    diff_result = {"before": "", "after": ""}
+
+    if state == "present":
+        if existing_id:
+            diff_result["before"] = "state: present\n"
+            # Compare roleAssignments to detect if update is needed
+            if existing_data.get("roleAssignments") != data["roleAssignments"]:
+                if module.check_mode:
+                    diff_result["after"] = "state: updated\n"
+                    module.exit_json(changed=True, diff=diff_result)
+                ret = atlas.call_url(
+                    path="/roleMappings/{0}".format(existing_id),
+                    data=module.jsonify(data),
+                    method="PUT",
+                )
+                if ret["code"] == 200:
+                    changed = True
+                    diff_result["after"] = "state: updated\n"
+                else:
+                    module.fail_json(
+                        msg="bad return code while updating: %d. Error message: %s"
+                        % (ret["code"], ret["error"])
+                    )
+            else:
+                diff_result["after"] = "state: present\n"
+        else:
+            diff_result["before"] = "state: absent\n"
+            if module.check_mode:
+                diff_result["after"] = "state: created\n"
+                module.exit_json(changed=True, diff=diff_result)
+            ret = atlas.call_url(
+                path="/roleMappings",
+                data=module.jsonify(data),
+                method="POST",
+            )
+            if ret["code"] in (200, 201):
+                changed = True
+                diff_result["after"] = "state: created\n"
+            else:
+                module.fail_json(
+                    msg="bad return code while creating: %d. Error message: %s"
+                    % (ret["code"], ret["error"])
+                )
+
+    elif state == "absent":
+        if existing_id:
+            diff_result["before"] = "state: present\n"
+            if module.check_mode:
+                diff_result["after"] = "state: absent\n"
+                module.exit_json(changed=True, diff=diff_result)
+            ret = atlas.call_url(
+                path="/roleMappings/{0}".format(existing_id),
+                method="DELETE",
+            )
+            if ret["code"] in (200, 202, 204):
+                changed = True
+                diff_result["after"] = "state: absent\n"
+            else:
+                module.fail_json(
+                    msg="bad return code while deleting: %d. Error message: %s"
+                    % (ret["code"], ret["error"])
+                )
+        else:
+            diff_result["before"] = "state: absent\n"
+            diff_result["after"] = "state: absent\n"
+
+    module.exit_json(changed=changed, data=data, diff=diff_result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/mongodb_atlas_oidc_user.py
+++ b/plugins/modules/mongodb_atlas_oidc_user.py
@@ -29,7 +29,6 @@ options:
     description:
       - MongoDB Atlas Service Account client secret (OAuth2).
       - Mutually exclusive with C(api_password).
-    no_log: true
     type: str
     aliases: [ "serviceAccountSecret" ]
   api_username:
@@ -40,7 +39,6 @@ options:
   api_password:
     description:
       - Atlas API private key. Alternative to C(service_account_secret).
-    no_log: true
     type: str
     aliases: [ "apiPassword" ]
   group_id:

--- a/plugins/modules/mongodb_atlas_oidc_user.py
+++ b/plugins/modules/mongodb_atlas_oidc_user.py
@@ -1,0 +1,205 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: mongodb_atlas_oidc_user
+short_description: Manage OIDC database users in Atlas
+description:
+  - Manage OIDC-authenticated database users (human users and IdP groups) in MongoDB Atlas.
+  - Uses OAuth2 client_credentials (Service Account) for authentication.
+  - For oidc_auth_type USER the database_name must be C($external).
+  - For oidc_auth_type IDP_GROUP the database_name must be C(admin).
+  - L(API Documentation,https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Database-Users)
+author: "Karol Murawski (@kazz3m)"
+options:
+  service_account_id:
+    description:
+      - MongoDB Atlas Service Account client ID (OAuth2).
+      - Mutually exclusive with C(api_username).
+    type: str
+    aliases: [ "serviceAccountId" ]
+  service_account_secret:
+    description:
+      - MongoDB Atlas Service Account client secret (OAuth2).
+      - Mutually exclusive with C(api_password).
+    no_log: true
+    type: str
+    aliases: [ "serviceAccountSecret" ]
+  api_username:
+    description:
+      - Atlas API public key. Alternative to C(service_account_id).
+    type: str
+    aliases: [ "apiUsername" ]
+  api_password:
+    description:
+      - Atlas API private key. Alternative to C(service_account_secret).
+    no_log: true
+    type: str
+    aliases: [ "apiPassword" ]
+  group_id:
+    description:
+      - Unique identifier of the Atlas project (group).
+    required: true
+    type: str
+    aliases: [ "groupId" ]
+  state:
+    description:
+      - Desired state of the user.
+    choices: [ "present", "absent" ]
+    default: present
+    type: str
+  oidc_auth_type:
+    description:
+      - OIDC authentication type.
+      - C(USER) for individual human users authenticated via OIDC.
+      - C(IDP_GROUP) for IdP groups mapped to MongoDB roles.
+    choices: [ "USER", "IDP_GROUP" ]
+    default: IDP_GROUP
+    type: str
+    aliases: [ "oidcAuthType" ]
+  database_name:
+    description:
+      - Database against which Atlas authenticates the user.
+      - Must be C($external) for C(USER) and C(admin) for C(IDP_GROUP).
+    choices: [ "admin", "$external" ]
+    default: "$external"
+    type: str
+    aliases: [ "databaseName" ]
+  username:
+    description:
+      - Username for OIDC USER or IdP group identifier for IDP_GROUP.
+      - For IDP_GROUP format is C(<idp_id>/<group_name>).
+    required: true
+    type: str
+  roles:
+    description:
+      - Array of roles and the databases on which the roles apply.
+    required: true
+    type: list
+    elements: dict
+    suboptions:
+      database_name:
+        description:
+          - Database on which the user has the specified role.
+        required: true
+        type: str
+        aliases: [ "databaseName" ]
+      role_name:
+        description:
+          - Name of the role. Can be a built-in or custom role.
+        required: true
+        type: str
+        aliases: [ "roleName" ]
+'''
+
+EXAMPLES = '''
+- name: Create OIDC IDP_GROUP database user
+  community.mongodb.mongodb_atlas_oidc_user:
+    service_account_id: "mdb_sa_id_xxxx"
+    service_account_secret: "mdb_sa_sk_xxxx"
+    group_id: "6991db0a32bf1b56dbb63d62"
+    oidc_auth_type: "IDP_GROUP"
+    database_name: "admin"
+    username: "69d4192c57e96607c7180011/SG-DB-ROLE-APPOPS"
+    roles:
+      - database_name: admin
+        role_name: readViewOnboardingCustomerList
+
+- name: Create OIDC USER database user
+  community.mongodb.mongodb_atlas_oidc_user:
+    service_account_id: "mdb_sa_id_xxxx"
+    service_account_secret: "mdb_sa_sk_xxxx"
+    group_id: "6991db0a32bf1b56dbb63d62"
+    oidc_auth_type: "USER"
+    database_name: "$external"
+    username: "69d4192c57e96607c7180011/karol.murawski@d360.com"
+    roles:
+      - database_name: admin
+        role_name: dbAdminAnyDatabase
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.mongodb.plugins.module_utils.mongodb_atlas import (
+    AtlasAPIObjectV2,
+)
+
+
+def main():
+    argument_spec = dict(
+        state=dict(default="present", choices=["absent", "present"]),
+        service_account_id=dict(aliases=["serviceAccountId"]),
+        service_account_secret=dict(no_log=True, aliases=["serviceAccountSecret"]),
+        api_username=dict(aliases=["apiUsername"]),
+        api_password=dict(no_log=True, aliases=["apiPassword"]),
+        group_id=dict(required=True, aliases=["groupId"]),
+        oidc_auth_type=dict(default="IDP_GROUP", choices=["USER", "IDP_GROUP"], aliases=["oidcAuthType"]),
+        database_name=dict(default="$external", choices=["admin", "$external"], aliases=["databaseName"]),
+        username=dict(required=True),
+        roles=dict(
+            required=True,
+            type="list",
+            elements="dict",
+            options=dict(
+                database_name=dict(required=True, aliases=["databaseName"]),
+                role_name=dict(required=True, aliases=["roleName"]),
+            ),
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec, supports_check_mode=True
+    )
+
+    data = {
+        "databaseName": module.params["database_name"],
+        "oidcAuthType": module.params["oidc_auth_type"],
+        "username": module.params["username"],
+        "roles": [],
+    }
+
+    for role in module.params.get("roles"):
+        data["roles"].append({
+            "databaseName": role.get("database_name"),
+            "roleName": role.get("role_name"),
+        })
+
+    base_url = (
+        "https://cloud.mongodb.com/api/atlas/v2/groups/"
+        + module.params["group_id"]
+    )
+
+    try:
+        atlas = AtlasAPIObjectV2(
+            module=module,
+            path="/databaseUsers",
+            object_name="username",
+            group_id=module.params["group_id"],
+            data=data,
+            base_url=base_url,
+            service_account_id=module.params.get("service_account_id"),
+            service_account_secret=module.params.get("service_account_secret"),
+            api_username=module.params.get("api_username"),
+            api_password=module.params.get("api_password"),
+        )
+    except Exception as e:
+        module.fail_json(
+            msg="unable to connect to Atlas API. Exception message: %s" % e
+        )
+
+    changed, diff = atlas.update(module.params["state"])
+    module.exit_json(
+        changed=changed,
+        data=atlas.data,
+        diff=diff,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/mongodb_atlas_org_invite.py
+++ b/plugins/modules/mongodb_atlas_org_invite.py
@@ -29,7 +29,6 @@ options:
     description:
       - MongoDB Atlas Service Account client secret (OAuth2).
       - Mutually exclusive with C(api_password).
-    no_log: true
     type: str
     aliases: [ "serviceAccountSecret" ]
   api_username:
@@ -40,7 +39,6 @@ options:
   api_password:
     description:
       - Atlas API private key. Alternative to C(service_account_secret).
-    no_log: true
     type: str
     aliases: [ "apiPassword" ]
   org_id:
@@ -289,7 +287,7 @@ def main():
                 module.exit_json(changed=True, diff=diff_result)
 
             url = "{0}/orgs/{1}/invites/{2}".format(ATLAS_BASE, org_id, pending_invite["id"])
-            status, _ = call_url(module, url, method="DELETE", token=token)
+            status, _ignored = call_url(module, url, method="DELETE", token=token)
             if status == 204:
                 changed = True
                 diff_result["after"] = "state: absent\n"

--- a/plugins/modules/mongodb_atlas_org_invite.py
+++ b/plugins/modules/mongodb_atlas_org_invite.py
@@ -1,0 +1,308 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: mongodb_atlas_org_invite
+short_description: Manage Atlas organization user invitations
+description:
+  - Invite users to a MongoDB Atlas organization with specified org and project roles.
+  - If the user already exists in the org, the module reports no change (idempotent).
+  - If a pending invite for the user already exists, the module reports no change.
+  - Uses OAuth2 client_credentials (Service Account) for authentication.
+  - L(API Documentation,https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations)
+author: "Karol Murawski (@kazz3m)"
+options:
+  service_account_id:
+    description:
+      - MongoDB Atlas Service Account client ID (OAuth2).
+      - Mutually exclusive with C(api_username).
+    type: str
+    aliases: [ "serviceAccountId" ]
+  service_account_secret:
+    description:
+      - MongoDB Atlas Service Account client secret (OAuth2).
+      - Mutually exclusive with C(api_password).
+    no_log: true
+    type: str
+    aliases: [ "serviceAccountSecret" ]
+  api_username:
+    description:
+      - Atlas API public key. Alternative to C(service_account_id).
+    type: str
+    aliases: [ "apiUsername" ]
+  api_password:
+    description:
+      - Atlas API private key. Alternative to C(service_account_secret).
+    no_log: true
+    type: str
+    aliases: [ "apiPassword" ]
+  org_id:
+    description:
+      - Unique identifier of the Atlas organization.
+    required: true
+    type: str
+    aliases: [ "orgId" ]
+  state:
+    description:
+      - C(present) ensures the user is invited or already a member.
+      - C(absent) removes a pending invitation (does not remove existing org members).
+    choices: [ "present", "absent" ]
+    default: present
+    type: str
+  username:
+    description:
+      - Email address of the user to invite.
+    required: true
+    type: str
+  roles:
+    description:
+      - List of org-level roles to assign (e.g. ORG_OWNER, ORG_MEMBER, ORG_READ_ONLY).
+    required: true
+    type: list
+    elements: str
+  group_role_assignments:
+    description:
+      - Optional list of project-level role assignments.
+    type: list
+    elements: dict
+    default: []
+    suboptions:
+      group_id:
+        description:
+          - Atlas project ID.
+        required: true
+        type: str
+        aliases: [ "groupId" ]
+      roles:
+        description:
+          - List of project-level roles (e.g. GROUP_READ_ONLY, GROUP_DATA_ACCESS_READ_ONLY).
+        required: true
+        type: list
+        elements: str
+'''
+
+EXAMPLES = '''
+- name: Invite user as org owner
+  community.mongodb.mongodb_atlas_org_invite:
+    service_account_id: "mdb_sa_id_xxxx"
+    service_account_secret: "mdb_sa_sk_xxxx"
+    org_id: "694ec9ddbaecce170ffe8b62"
+    username: "newuser@d360.com"
+    roles:
+      - ORG_OWNER
+
+- name: Invite user with org and project roles
+  community.mongodb.mongodb_atlas_org_invite:
+    service_account_id: "mdb_sa_id_xxxx"
+    service_account_secret: "mdb_sa_sk_xxxx"
+    org_id: "694ec9ddbaecce170ffe8b62"
+    username: "analyst@d360.com"
+    roles:
+      - ORG_MEMBER
+    group_role_assignments:
+      - group_id: "6991db0a32bf1b56dbb63d62"
+        roles:
+          - GROUP_READ_ONLY
+
+- name: Revoke pending invitation
+  community.mongodb.mongodb_atlas_org_invite:
+    service_account_id: "mdb_sa_id_xxxx"
+    service_account_secret: "mdb_sa_sk_xxxx"
+    org_id: "694ec9ddbaecce170ffe8b62"
+    username: "newuser@d360.com"
+    roles: []
+    state: absent
+'''
+
+import json
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
+from ansible_collections.community.mongodb.plugins.module_utils.mongodb_atlas import (
+    get_bearer_token,
+    ATLAS_API_V2_VERSION,
+)
+
+ATLAS_BASE = "https://cloud.mongodb.com/api/atlas/v2"
+
+
+def call_url(module, url, method="GET", data=None, token=None):
+    headers = {
+        "Accept": "application/vnd.atlas.{0}+json".format(ATLAS_API_V2_VERSION),
+        "Content-Type": "application/vnd.atlas.{0}+json".format(ATLAS_API_V2_VERSION),
+    }
+    if token:
+        headers["Authorization"] = "Bearer {0}".format(token)
+    rsp, info = fetch_url(
+        module=module,
+        url=url,
+        data=module.jsonify(data) if data is not None else None,
+        headers=headers,
+        method=method,
+    )
+    content = {}
+    if rsp and info["status"] not in (204, 404):
+        try:
+            content = json.loads(rsp.read())
+        except ValueError:
+            pass
+    return info["status"], content
+
+
+def get_existing_member(module, token, org_id, username):
+    """Return user dict if already an org member, else None."""
+    page = 1
+    while True:
+        url = "{0}/orgs/{1}/users?pageNum={2}&itemsPerPage=100".format(ATLAS_BASE, org_id, page)
+        status, data = call_url(module, url, token=token)
+        if status != 200:
+            return None
+        for user in data.get("results", []):
+            if user.get("username", "").lower() == username.lower():
+                return user
+        if len(data.get("results", [])) < 100:
+            break
+        page += 1
+    return None
+
+
+def get_pending_invite(module, token, org_id, username):
+    """Return invite dict if a pending invite exists for username, else None."""
+    url = "{0}/orgs/{1}/invites".format(ATLAS_BASE, org_id)
+    status, data = call_url(module, url, token=token)
+    if status != 200:
+        return None
+    if isinstance(data, list):
+        results = data
+    else:
+        results = data.get("results", [])
+    for invite in results:
+        if invite.get("username", "").lower() == username.lower():
+            return invite
+    return None
+
+
+def main():
+    argument_spec = dict(
+        state=dict(default="present", choices=["absent", "present"]),
+        service_account_id=dict(aliases=["serviceAccountId"]),
+        service_account_secret=dict(no_log=True, aliases=["serviceAccountSecret"]),
+        api_username=dict(aliases=["apiUsername"]),
+        api_password=dict(no_log=True, aliases=["apiPassword"]),
+        org_id=dict(required=True, aliases=["orgId"]),
+        username=dict(required=True),
+        roles=dict(required=True, type="list", elements="str"),
+        group_role_assignments=dict(
+            type="list",
+            elements="dict",
+            default=[],
+            options=dict(
+                group_id=dict(required=True, aliases=["groupId"]),
+                roles=dict(required=True, type="list", elements="str"),
+            ),
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec, supports_check_mode=True
+    )
+
+    if module.params.get("service_account_id") and module.params.get("service_account_secret"):
+        token = get_bearer_token(
+            module,
+            module.params["service_account_id"],
+            module.params["service_account_secret"],
+        )
+        # Digest auth not used — clear any url_username to avoid conflicts
+    elif module.params.get("api_username") and module.params.get("api_password"):
+        token = None
+        module.params["url_username"] = module.params["api_username"]
+        module.params["url_password"] = module.params["api_password"]
+    else:
+        module.fail_json(
+            msg="Either service_account_id/service_account_secret or api_username/api_password must be provided."
+        )
+
+    org_id = module.params["org_id"]
+    username = module.params["username"]
+    state = module.params["state"]
+
+    group_role_assignments = [
+        {
+            "groupId": gra["group_id"],
+            "groupRoles": gra["roles"],
+        }
+        for gra in module.params.get("group_role_assignments") or []
+    ]
+
+    existing_member = get_existing_member(module, token, org_id, username)
+    pending_invite = get_pending_invite(module, token, org_id, username)
+
+    changed = False
+    diff_result = {"before": "", "after": ""}
+
+    if state == "present":
+        if existing_member:
+            # User already in org - nothing to do
+            diff_result["before"] = "state: member\n"
+            diff_result["after"] = "state: member\n"
+        elif pending_invite:
+            # Invite already pending - nothing to do
+            diff_result["before"] = "state: invited\n"
+            diff_result["after"] = "state: invited\n"
+        else:
+            diff_result["before"] = "state: absent\n"
+            if module.check_mode:
+                diff_result["after"] = "state: invited\n"
+                module.exit_json(changed=True, diff=diff_result)
+
+            invite_data = {
+                "username": username,
+                "roles": module.params["roles"],
+                "groupRoleAssignments": group_role_assignments,
+            }
+            url = "{0}/orgs/{1}/invites".format(ATLAS_BASE, org_id)
+            status, data = call_url(module, url, method="POST", data=invite_data, token=token)
+            if status in (200, 201):
+                changed = True
+                diff_result["after"] = "state: invited\n"
+            else:
+                error = data.get("reason", "unknown")
+                if "detail" in data:
+                    error += ". Detail: " + data["detail"]
+                module.fail_json(
+                    msg="bad return code while inviting: %d. Error message: %s" % (status, error)
+                )
+
+    elif state == "absent":
+        if pending_invite:
+            diff_result["before"] = "state: invited\n"
+            if module.check_mode:
+                diff_result["after"] = "state: absent\n"
+                module.exit_json(changed=True, diff=diff_result)
+
+            url = "{0}/orgs/{1}/invites/{2}".format(ATLAS_BASE, org_id, pending_invite["id"])
+            status, _ = call_url(module, url, method="DELETE", token=token)
+            if status == 204:
+                changed = True
+                diff_result["after"] = "state: absent\n"
+            else:
+                module.fail_json(
+                    msg="bad return code while deleting invite: %d" % status
+                )
+        else:
+            diff_result["before"] = "state: absent\n"
+            diff_result["after"] = "state: absent\n"
+
+    module.exit_json(changed=changed, diff=diff_result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
##### SUMMARY
- mongodb_atlas.py: add get_bearer_token() helper and AtlasAPIObjectV2 supporting both OAuth2 Bearer (Service Account) and Digest (API key) authentication against Atlas API v2
- mongodb_atlas_oidc_user: manage OIDC USER and IDP_GROUP database users
- mongodb_atlas_federation_role_mapping: manage SAML/SSO group to Atlas role mappings; implements custom exists/create/update/delete logic because /roleMappings API uses ObjectId (not name) for single-item ops and returns HTTP 200 (not 201) on create
- mongodb_atlas_org_invite: invite users to Atlas org with org and project role assignments; idempotent (skips existing members/invites)

All new modules support both service_account_id/secret and api_username/api_password authentication.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- oidc user
- federation role mapping (SAML)
