### PR TITLE
Replace ansible.module_utils.six with Python stdlib equivalents

### DIFF
--- a/changelogs/fragments/remove-module-utils-six.yml
+++ b/changelogs/fragments/remove-module-utils-six.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Replace the deprecated ``ansible.module_utils.six`` compatibility shims with
+    their Python standard library equivalents. ``ansible.module_utils.six`` is
+    deprecated in ansible-core 2.20 and is scheduled for removal in 2.24.

--- a/docs/mongodb_module.template.py
+++ b/docs/mongodb_module.template.py
@@ -47,9 +47,9 @@ mongodb_value:
   type: <DATA TYPE>
 '''
 
+import configparser
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import binary_type, text_type
-from ansible.module_utils.six.moves import configparser
 from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.mongodb.plugins.module_utils.mongodb_common import (
     check_compatibility,

--- a/plugins/lookup/mongodb.py
+++ b/plugins/lookup/mongodb.py
@@ -154,7 +154,6 @@ RETURN = """
 
 import datetime
 
-from ansible.module_utils.six import string_types, integer_types  # pylint: disable=ansible-bad-import-from
 from ansible.module_utils.common.text.converters import to_native
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
@@ -200,9 +199,9 @@ class LookupModule(LookupBase):
     def convert_mongo_result_to_valid_json(self, result):
         if result is None:
             return result
-        if isinstance(result, integer_types + (float, bool)):
+        if isinstance(result, (int, float, bool)):
             return result
-        if isinstance(result, string_types):
+        if isinstance(result, str):
             return result
         elif isinstance(result, list):
             new_list = []

--- a/plugins/module_utils/mongodb_common.py
+++ b/plugins/module_utils/mongodb_common.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
+import configparser
+
 from ansible.module_utils.basic import missing_required_lib  # pylint: disable=unused-import:
-from ansible.module_utils.six.moves import configparser
 from ansible.module_utils.common.text.converters import to_native
 import traceback
 import os

--- a/plugins/modules/mongodb_info.py
+++ b/plugins/modules/mongodb_info.py
@@ -105,7 +105,6 @@ from uuid import UUID
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible.module_utils.six import iteritems  # pylint: disable=ansible-bad-import-from
 from ansible_collections.community.mongodb.plugins.module_utils.mongodb_common import (
     convert_bson_values_recur,
     get_mongodb_client,
@@ -189,7 +188,7 @@ class MongoDbInfo():
         # Gather info about databases and their total size:
         self.info['databases'], self.info['total_size'] = self.get_db_info()
 
-        for dbname, val in iteritems(self.info['databases']):
+        for dbname, val in self.info['databases'].items():
             # Gather info about users for each database:
             self.info['users'].update(self.get_users_info(dbname))
 
@@ -212,7 +211,7 @@ class MongoDbInfo():
         roles_dict = {}
         for elem in result:
             roles_dict[elem['role']] = {}
-            for key, val in iteritems(elem):
+            for key, val in elem.items():
                 if key in ['role', 'db']:
                     continue
 
@@ -234,7 +233,7 @@ class MongoDbInfo():
         users_dict = {}
         for elem in result:
             users_dict[elem['user']] = {}
-            for key, val in iteritems(elem):
+            for key, val in elem.items():
                 if key in ['user', 'db']:
                     continue
 
@@ -257,7 +256,7 @@ class MongoDbInfo():
         db_dict = {}
         for elem in result:
             db_dict[elem['name']] = {}
-            for key, val in iteritems(elem):
+            for key, val in elem.items():
                 if key == 'name':
                     continue
 

--- a/plugins/modules/mongodb_user.py
+++ b/plugins/modules/mongodb_user.py
@@ -222,7 +222,6 @@ import traceback
 
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils.six import binary_type, text_type  # pylint: disable=ansible-bad-import-from
 from ansible.module_utils.common.text.converters import to_native, to_bytes
 from ansible_collections.community.mongodb.plugins.module_utils.mongodb_common import (
     missing_required_lib,
@@ -348,7 +347,7 @@ def check_if_roles_changed(uinfo, roles, db_name):
 def make_sure_roles_are_a_list_of_dict(roles, db_name):
     output = list()
     for role in roles:
-        if isinstance(role, (binary_type, text_type)):
+        if isinstance(role, (bytes, str)):
             new_role = {"role": role, "db": db_name}
             output.append(new_role)
         else:


### PR DESCRIPTION
##### SUMMARY

`ansible.module_utils.six` is deprecated in ansible-core 2.20 and scheduled for removal in 2.24. Every use in this collection has a direct stdlib equivalent:

| six | stdlib |
| --- | --- |
| `six.moves configparser` | `configparser` |
| `iteritems(d)` | `d.items()` |
| `string_types` | `str` |
| `integer_types` | `int` |
| `binary_type`, `text_type` | `bytes`, `str` |

One case needed care: `plugins/lookup/mongodb.py` used `isinstance(result, integer_types + (float, bool))`, a tuple concatenation. Since `integer_types` is `(int,)` on Python 3, that becomes `isinstance(result, (int, float, bool))` rather than a bare `int`. The `# pylint: disable=ansible-bad-import-from` comments went away with the imports they annotated. A changelog fragment is included.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

mongodb_info, mongodb_user, lookup/mongodb, module_utils/mongodb_common
