### PR TITLE
Add modern debians support

### DIFF
--- a/roles/mongodb_linux/tasks/main.yml
+++ b/roles/mongodb_linux/tasks/main.yml
@@ -86,7 +86,7 @@
     group: root
     mode: '0755'
   when: 
-    - ansible_facts.distribution == "Debian"
+    - ansible_facts.distribution in ['Debian', 'Ubuntu']
 
 - name: Create override.conf to disable ConditionVirtualization for systemd-timesyncd.service
   copy:
@@ -98,7 +98,7 @@
     group: root
     mode: '0644'
   when: 
-    - ansible_facts.distribution == "Debian"
+    - ansible_facts.distribution in ['Debian', 'Ubuntu']
   register: timesync
 
 - name: Reload systemd manager configuration

--- a/roles/mongodb_linux/vars/Debian-13.yml
+++ b/roles/mongodb_linux/vars/Debian-13.yml
@@ -1,0 +1,5 @@
+---
+# Packages for Debian 13
+ntp_service: ntpsec.service
+ntp_package: ntpsec
+gnu_c_lib: libc6

--- a/roles/mongodb_linux/vars/Ubuntu-22.04.yml
+++ b/roles/mongodb_linux/vars/Ubuntu-22.04.yml
@@ -1,0 +1,5 @@
+---
+# Packages for Ubuntu
+ntp_service: systemd-timesyncd
+ntp_package: systemd-timesyncd
+gnu_c_lib: libc6

--- a/roles/mongodb_linux/vars/Ubuntu-24.04.yml
+++ b/roles/mongodb_linux/vars/Ubuntu-24.04.yml
@@ -1,0 +1,5 @@
+---
+# Packages for Ubuntu
+ntp_service: systemd-timesyncd
+ntp_package: systemd-timesyncd
+gnu_c_lib: libc6

--- a/roles/mongodb_linux/vars/Ubuntu-26.04.yml
+++ b/roles/mongodb_linux/vars/Ubuntu-26.04.yml
@@ -1,0 +1,5 @@
+---
+# Packages for Ubuntu
+ntp_service: systemd-timesyncd
+ntp_package: systemd-timesyncd
+gnu_c_lib: libc6


### PR DESCRIPTION
I have updated and tested the installation on popular Debian distributions. Everything works. It seems that MongoDB does not yet provide a repository for Debian 13, but we can proceed with preparations for it.